### PR TITLE
get post ancestors

### DIFF
--- a/wp-includes/post.php
+++ b/wp-includes/post.php
@@ -434,7 +434,7 @@ function get_post_ancestors($post) {
 		_get_post_ancestors( $post );
 
 	if ( ! empty( $post->ancestors ) )
-		return $post->ancestors;
+		return array_reverse($post->ancestors);
 
 	return array();
 }


### PR DESCRIPTION
The codex stated that the parent page would be first result in the array, but it is actually last. I changed codex to reflect that. If being first is actually the desired result, we can just reverse the array.

makes more sense for it to be first so that we always know where it is in the array, no matter how many sub pages might get created.
