### PR TITLE
has_cap no longer has two arguments, reflect that in the description

### DIFF
--- a/wp-includes/capabilities.php
+++ b/wp-includes/capabilities.php
@@ -840,14 +840,12 @@ class WP_User {
 	 * Whether user has capability or role name.
 	 *
 	 * This is useful for looking up whether the user has a specific role
-	 * assigned to the user. The second optional parameter can also be used to
-	 * check for capabilities against a specific post.
+	 * assigned to the user.
 	 *
 	 * @since 2.0.0
 	 * @access public
 	 *
 	 * @param string|int $cap Capability or role name to search.
-	 * @param int $post_id Optional. Post ID to check capability against specific post.
 	 * @return bool True, if user has capability; false, if user does not have capability.
 	 */
 	function has_cap( $cap ) {


### PR DESCRIPTION
has_cap no longer has two arguments, reflect that in the function description comment
