### PR TITLE
Get calendar custom post type

### DIFF
--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -1070,6 +1070,7 @@ function calendar_week_mod($num) {
  *
  * @param bool $initial Optional, default is true. Use initial calendar names.
  * @param bool $echo Optional, default is true. Set to false for return.
+ * @param string $post_type Optional, default is post. Set to your custom post type.
  */
 function get_calendar($initial = true, $echo = true, $post_type = 'post') {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;


### PR DESCRIPTION
With the addition of the third argument to the function get_calendar(), we can use this function with any custom post types.
