### PR TITLE
Fix broken style import path in tinymce wp_theme skin

### DIFF
--- a/wp-includes/js/tinymce/themes/advanced/skins/wp_theme/ui.css
+++ b/wp-includes/js/tinymce/themes/advanced/skins/wp_theme/ui.css
@@ -1,2 +1,2 @@
-/* not used, included for back-compat, see wp-includes/css/editor-buttons.css */
-@import url("../../../../../../css/editor-buttons.css?ver=20111114");
+/* not used, included for back-compat, see wp-includes/css/editor.css (formerly editor-buttons.css) */
+@import url("../../../../../../css/editor.css?ver=20111114");


### PR DESCRIPTION
The file editor-buttons.css was recently renamed to editor.css in wp-includes/css, but this reference wasn't updated.
