### PR TITLE
Filter preview url

### DIFF
--- a/wp-admin/includes/post.php
+++ b/wp-admin/includes/post.php
@@ -1319,6 +1319,7 @@ function post_preview() {
 		$nonce = wp_create_nonce('post_preview_' . $id);
 		$url = add_query_arg( array( 'preview' => 'true', 'preview_id' => $id, 'preview_nonce' => $nonce ), get_permalink($id) );
 	}
+	$url = apply_filters( 'preview_post_link', $url );
 
 	return $url;
 }


### PR DESCRIPTION
The current preview_post_link hook only hooks non-published posts. This adds a filter to published posts as well with the same expected hook.
