### PR TITLE
Fixing strict standards violation

### DIFF
--- a/wp-includes/pomo/mo.php
+++ b/wp-includes/pomo/mo.php
@@ -207,7 +207,8 @@ class MO extends Gettext_Translations {
 			$translation = $reader->substr( $strings, $t['pos'], $t['length'] );
 
 			if ('' === $original) {
-				$this->set_headers($this->make_headers($translation));
+				$headers = $this->make_headers($translation);
+				$this->set_headers($headers);
 			} else {
 				$entry = &$this->make_entry($original, $translation);
 				$this->entries[$entry->key()] = &$entry;


### PR DESCRIPTION
Strict Standards: Only variables should be passed by reference in /var/www/wordpress/wp-includes/pomo/mo.php on line 211
