### PR TITLE
Bugfix - uploading post thumbnails.

### DIFF
--- a/wp-includes/pomo/translations.php
+++ b/wp-includes/pomo/translations.php
@@ -164,12 +164,12 @@ class Gettext_Translations extends Translations {
 	 * plural forms header
 	 */
 	function make_plural_form_function($nplurals, $expression) {
-		$expression = str_replace('n', '$n', $expression);
-		$func_body = "
+                str_replace(array('n', '< =', '> ='), array('$n', '<=', '>='), $expression);
+                $func_body = "
 			\$index = (int)($expression);
 			return (\$index < $nplurals)? \$index : $nplurals - 1;";
 		return create_function('$n', $func_body);
-	}
+        }
 
 	/**
 	 * Adds parantheses to the inner parts of ternary operators in


### PR DESCRIPTION
#### I was not able to upload post thumbnail or browse my library for thumbnail.

In my errorlog I found:

```
PHP Parse error:  syntax error, unexpected '=' in /*wordpressdir*/wp-includes/pomo/translations.php(171) : runtime-created function on line 1
```

I think it is caused by translation file, because problematic expression was:

```
($n==1  ? ( 0 ) : ( $n%10>=2 && $n%10< =4 && ($n%100<10 or $n%100>=20)  ? ( 1 ) : ( 2)))
```

You just need to replace **< =** to **<=** and so on.
My locales are **pl_PL**.

I know it's walkaway, but it works! :)
