### PR TITLE
Proposed benchmarking functionality to provide deeper insight into the performance of WordPress.

### DIFF
--- a/wp-includes/default-constants.php
+++ b/wp-includes/default-constants.php
@@ -64,6 +64,9 @@ function wp_initial_constants() {
 	if ( !defined('WP_CACHE') )
 		define('WP_CACHE', false);
 
+	if ( !defined('WP_BENCHMARK') )
+		define('WP_BENCHMARK', false);
+
 	/**
 	 * Private
 	 */


### PR DESCRIPTION
I've been trying to figure out how I could better gain insight into who WordPress is performing. After a great deal of thought, trial and error, here is a proposed API for benchmarking complete with integration in the hooks API.

The things that I remain unsure about include:
- Should we offer more parameters to the wp_benchmark function?
- Should we store benchmark groups in an option? Or should it be managed by an array in wp-config?
  Is there a way to keep the wp_benchmark function generalized while having less code wrapping the benchmark target (such as in the hooks function).
