### PR TITLE
Patch to enable developers to use different orderings per field specifie...

### DIFF
--- a/wp-includes/query.php
+++ b/wp-includes/query.php
@@ -2390,9 +2390,17 @@ class WP_Query {
 
 		$where .= $search . $whichauthor . $whichmimetype;
 
-		if ( empty($q['order']) || ((strtoupper($q['order']) != 'ASC') && (strtoupper($q['order']) != 'DESC')) )
-			$q['order'] = 'DESC';
-
+		if (empty($q['order'])) {
+			$orderings = array('DESC');
+		} else {
+			$orderings = explode(' ', $q['order']);
+			foreach ($orderings as $i => $order) {
+				if (strtoupper($order) != 'ASC' && strtoupper($order) != 'ASC') {
+					$orderings[$i] = 'DESC';
+				}
+			}
+		}
+		
 		// Order by
 		if ( empty($q['orderby']) ) {
 			$orderby = "$wpdb->posts.post_date " . $q['order'];
@@ -2447,6 +2455,14 @@ class WP_Query {
 					default:
 						$orderby = "$wpdb->posts.post_" . $orderby;
 				}
+				
+				if (isset($orderings[$i])) {
+					$order = $orderings[$i];
+					$orderby .= " {$order}";
+				} else if (count($orderings) == 1) {
+					$order = reset($orderings);
+					$orderby .= " {$order}";	
+				}
 
 				$orderby_array[] = $orderby;
 			}
@@ -2454,8 +2470,7 @@ class WP_Query {
 
 			if ( empty( $orderby ) )
 				$orderby = "$wpdb->posts.post_date ".$q['order'];
-			else
-				$orderby .= " {$q['order']}";
+			
 		}
 
 		if ( is_array( $post_type ) && count( $post_type ) > 1 ) {


### PR DESCRIPTION
I want a query ordered by menu order and date with both columns sorted in DESC order.

My code is:

```
$query = new WP_Query(array(
    'orderby'           => 'menu_order date',
    'order'             => 'DESC',
));
```

But WP_Query creates this query (which MySQL sorts menu_order ASC because no column ordering was specified):

```
ORDER BY wp_posts.menu_order,wp_posts.post_date DESC
```

This PR will create this query:  

```
ORDER BY wp_posts.menu_order DESC,wp_posts.post_date DESC
```

Or if `'order' => 'DESC ASC'` it will create this query:

```
ORDER BY wp_posts.menu_order DESC,wp_posts.post_date ASC
```
