### PR TITLE
Fix regular expression used for smiley translations to work when there is only one registered emoticon.

### DIFF
--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -2585,7 +2585,7 @@ function smilies_init() {
 		$wp_smiliessearch .= preg_quote($rest, '/');
 	}
 
-	$wp_smiliessearch .= ')(?:\s|$)/m';
+	$wp_smiliessearch .= ')|(?:\s|^)(?:\s|$)/m';
 }
 
 /**


### PR DESCRIPTION
Without this patch, the string ":) :) :) :)" will not be replaced with four smilies when ":)" is the only emoticon in $wpsmiliestrans from smilies_init(), wp-includes/functions.php.
