### PR TITLE
Update default-widgets.php fixing according W3C

### DIFF
--- a/wp-includes/default-widgets.php
+++ b/wp-includes/default-widgets.php
@@ -165,13 +165,13 @@ class WP_Widget_Links extends WP_Widget {
 		</select>
 		</p>
 		<p>
-		<input class="checkbox" type="checkbox" <?php checked($instance['images'], true) ?> id="<?php echo $this->get_field_id('images'); ?>" name="<?php echo $this->get_field_name('images'); ?>" />
+		<input class="checkbox" type="checkbox" <?php checked($instance['images'], 'on') ?> id="<?php echo $this->get_field_id('images'); ?>" name="<?php echo $this->get_field_name('images'); ?>" />
 		<label for="<?php echo $this->get_field_id('images'); ?>"><?php _e('Show Link Image'); ?></label><br />
-		<input class="checkbox" type="checkbox" <?php checked($instance['name'], true) ?> id="<?php echo $this->get_field_id('name'); ?>" name="<?php echo $this->get_field_name('name'); ?>" />
+		<input class="checkbox" type="checkbox" <?php checked($instance['name'], 'on') ?> id="<?php echo $this->get_field_id('name'); ?>" name="<?php echo $this->get_field_name('name'); ?>" />
 		<label for="<?php echo $this->get_field_id('name'); ?>"><?php _e('Show Link Name'); ?></label><br />
-		<input class="checkbox" type="checkbox" <?php checked($instance['description'], true) ?> id="<?php echo $this->get_field_id('description'); ?>" name="<?php echo $this->get_field_name('description'); ?>" />
+		<input class="checkbox" type="checkbox" <?php checked($instance['description'], 'on') ?> id="<?php echo $this->get_field_id('description'); ?>" name="<?php echo $this->get_field_name('description'); ?>" />
 		<label for="<?php echo $this->get_field_id('description'); ?>"><?php _e('Show Link Description'); ?></label><br />
-		<input class="checkbox" type="checkbox" <?php checked($instance['rating'], true) ?> id="<?php echo $this->get_field_id('rating'); ?>" name="<?php echo $this->get_field_name('rating'); ?>" />
+		<input class="checkbox" type="checkbox" <?php checked($instance['rating'], 'on') ?> id="<?php echo $this->get_field_id('rating'); ?>" name="<?php echo $this->get_field_name('rating'); ?>" />
 		<label for="<?php echo $this->get_field_id('rating'); ?>"><?php _e('Show Link Rating'); ?></label>
 		</p>
 		<p>
@@ -1096,7 +1096,7 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
  * Navigation Menu widget class
  *
  * @since 3.0.0
- */
+ */l
  class WP_Nav_Menu_Widget extends WP_Widget {
 
 	function __construct() {


### PR DESCRIPTION
The internals of `checked` (`__checked_selected_helper`) 
`uses (string) $helper === (string) $current`.
If compared to TRUE, it doesn't works.
So I suggest changing to 'on' that seem to be the value used W3C http://www.w3.org/TR/html401/interact/forms.html#h-17.2.1