### PR TITLE
bugfix for QQMail link display error.

### DIFF
--- a/wp-login.php
+++ b/wp-login.php
@@ -361,7 +361,7 @@ function retrieve_password() {
 	$message .= sprintf(__('Username: %s'), $user_login) . "\r\n\r\n";
 	$message .= __('If this was a mistake, just ignore this email and nothing will happen.') . "\r\n\r\n";
 	$message .= __('To reset your password, visit the following address:') . "\r\n\r\n";
-	$message .= '<' . network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user_login), 'login') . ">\r\n";
+	$message .= network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user_login), 'login') . "\r\n";
 
 	if ( is_multisite() )
 		$blogname = $GLOBALS['current_site']->site_name;


### PR DESCRIPTION
Function "retrieve_password" will send user an e-mail, if user's e-mail address ends of qq.com, a symbol will be appended to the end of the link which is in the mail, eg.: 
`/wp-login.php?action=rp&key=YyV********5jKj&login=soulteary>`

detail:
http://www.soulteary.com/2013/12/12/wordpress-for-sae-send-mail.html