### PR TITLE
dbDelta() can't process lower-case SQL Keywords

### DIFF
--- a/wp-admin/includes/upgrade.php
+++ b/wp-admin/includes/upgrade.php
@@ -1645,14 +1645,14 @@ function dbDelta( $queries = '', $execute = true ) {
 
 	// Create a tablename index for an array ($cqueries) of queries
 	foreach($queries as $qry) {
-		if (preg_match("|CREATE TABLE ([^ ]*)|", $qry, $matches)) {
+		if (preg_match("|CREATE TABLE ([^ ]*)|i", $qry, $matches)) {
 			$cqueries[ trim( $matches[1], '`' ) ] = $qry;
 			$for_update[$matches[1]] = 'Created table '.$matches[1];
-		} else if (preg_match("|CREATE DATABASE ([^ ]*)|", $qry, $matches)) {
+		} else if (preg_match("|CREATE DATABASE ([^ ]*)|i", $qry, $matches)) {
 			array_unshift($cqueries, $qry);
-		} else if (preg_match("|INSERT INTO ([^ ]*)|", $qry, $matches)) {
+		} else if (preg_match("|INSERT INTO ([^ ]*)|i", $qry, $matches)) {
 			$iqueries[] = $qry;
-		} else if (preg_match("|UPDATE ([^ ]*)|", $qry, $matches)) {
+		} else if (preg_match("|UPDATE ([^ ]*)|i", $qry, $matches)) {
 			$iqueries[] = $qry;
 		} else {
 			// Unrecognized query type


### PR DESCRIPTION
SQL keywords in both of upper-case and lower-case is valid.
