### PR TITLE
Allow all Iris options to be overridden via wpColorPicker

### DIFF
--- a/wp-admin/js/color-picker.js
+++ b/wp-admin/js/color-picker.js
@@ -16,6 +16,7 @@
 			clear: false,
 			hide: true,
 			palettes: true,
+			width: 255,
 			mode: 'hsv'
 		},
 		_create: function() {
@@ -52,7 +53,7 @@
 			el.iris( {
 				target: self.pickerContainer,
 				hide: self.options.hide,
-				width: 255,
+				width: self.options.width,
 				mode: self.options.mode,
 				palettes: self.options.palettes,
 				change: function( event, ui ) {


### PR DESCRIPTION
'mode' and 'width' are both hard-coded in the Iris config. No reason not to allow that to be overridden via the wpColorPicker config.
