### PR TITLE
Improve argument handling for shortcodes

### DIFF
--- a/wp-includes/shortcodes.php
+++ b/wp-includes/shortcodes.php
@@ -347,13 +347,8 @@ function shortcode_parse_atts($text) {
  */
 function shortcode_atts( $pairs, $atts, $shortcode = '' ) {
 	$atts = (array)$atts;
-	$out = array();
-	foreach($pairs as $name => $default) {
-		if ( array_key_exists($name, $atts) )
-			$out[$name] = $atts[$name];
-		else
-			$out[$name] = $default;
-	}
+	$out = wp_parse_args( $atts, $pairs );
+
 	/**
 	 * Filter a shortcode's default attributes.
 	 *


### PR DESCRIPTION
Wordpress already has a function (`wp_parse_args`) to handle what was originally a re-implementation of PHP's `array_merge`. For simplicity and to reduce redundancy, I replaced the old loop with the wordpress-specific argument-set merging function.