### PR TITLE
Update file.php

### DIFF
--- a/wp-admin/includes/file.php
+++ b/wp-admin/includes/file.php
@@ -57,7 +57,7 @@ $wp_file_descriptions = array(
 function get_file_description( $file ) {
 	global $wp_file_descriptions;
 
-	if ( isset( $wp_file_descriptions[basename( $file )] ) ) {
+	if ( isset( $wp_file_descriptions[basename( $file )] ) and dirname($file)==get_template_directory() ) {
 		return $wp_file_descriptions[basename( $file )];
 	}
 	elseif ( file_exists( $file ) && is_file( $file ) ) {


### PR DESCRIPTION
If theme subfolders contains any index.php, page.php or something like these, wp-admin diplays those files with wrong title.
For example i have index.php in inc folder, thats what wp-admin dipslays:
https://dl.dropboxusercontent.com/u/22319935/github%20commits/wordpress/1/before.png
After change it will be so:
https://dl.dropboxusercontent.com/u/22319935/github%20commits/wordpress/1/after.png