### PR TITLE
Trim off trailing newline from current working directory. Newline causing segfault.

### DIFF
--- a/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -185,7 +185,7 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 	public function cwd() {
 		$cwd = $this->run_command('pwd');
 		if ( $cwd )
-			$cwd = trailingslashit($cwd);
+			$cwd = trailingslashit(rtrim($cwd));
 		return $cwd;
 	}
 


### PR DESCRIPTION
The trailling newline is causing a segfault when deleting a previously uploaded theme and when using SSH2 (FS_METHOD="ssh2"). The newline character is being kept after trailingslashit() is called, causing  the $cwd to look like: "/home/user/content\n/".