### PR TITLE
Update schema.php

### DIFF
--- a/wp-admin/includes/schema.php
+++ b/wp-admin/includes/schema.php
@@ -127,7 +127,8 @@ CREATE TABLE $wpdb->options (
   option_value longtext NOT NULL,
   autoload varchar(20) NOT NULL default 'yes',
   PRIMARY KEY  (option_id),
-  UNIQUE KEY option_name (option_name)
+  UNIQUE KEY option_name (option_name),
+  KEY autoload (autoload)
 ) $charset_collate;
 CREATE TABLE $wpdb->postmeta (
   meta_id bigint(20) unsigned NOT NULL auto_increment,


### PR DESCRIPTION
Add index on autoload column on options tables. 
To fix queries not using index -> SELECT option_name, option_value FROM wp_options WHERE autoload = 'S'