### PR TITLE
Add image caption markup filter

### DIFF
--- a/wp-includes/media.php
+++ b/wp-includes/media.php
@@ -852,6 +852,8 @@ function img_caption_shortcode( $attr, $content = null ) {
 
 	$class = trim( 'wp-caption ' . $atts['align'] . ' ' . $atts['class'] );
 
+	$atts['caption'] = apply_filters( 'img_caption_shortcode_caption_markup', $atts['caption'], $atts, preg_replace('/\D/', '', $atts['id']) );
+
 	if ( current_theme_supports( 'html5', 'caption' ) ) {
 		return '<figure ' . $atts['id'] . 'style="width: ' . (int) $atts['width'] . 'px;" class="' . esc_attr( $class ) . '">'
 		. do_shortcode( $content ) . '<figcaption class="wp-caption-text">' . $atts['caption'] . '</figcaption></figure>';


### PR DESCRIPTION
This would be great for anyone looking to add multiple elements nested within an image's `<figcaption>`.

For example:

```html
<figure id="attachment_91" style="width: 1024px;" class="wp-caption alignnone">
  <img class="size-large wp-image-91" src="http://example.dev/wp-content/uploads/2015/02/img01-1024x768.jpg" alt="This is the alt text" width="1024" height="768" />
  <figcaption class="wp-caption-text">
    <p class="wp-caption-text-credit">This is the image credit</p>
    <p class="wp-caption-text-caption">This is the image caption</p>
  </figcaption>
</figure>
```
