### PR TITLE
Get correct site_url even when using load balancer

### DIFF
--- a/wp-admin/includes/class-wp-list-table.php
+++ b/wp-admin/includes/class-wp-list-table.php
@@ -690,7 +690,7 @@ class WP_List_Table {
 
 		$current = $this->get_pagenum();
 
-		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+		$current_url = set_url_scheme( site_url($_SERVER['REQUEST_URI']) );
 
 		$current_url = remove_query_arg( array( 'hotkeys_highlight_last', 'hotkeys_highlight_first' ), $current_url );
 
@@ -861,7 +861,7 @@ class WP_List_Table {
 	public function print_column_headers( $with_id = true ) {
 		list( $columns, $hidden, $sortable ) = $this->get_column_info();
 
-		$current_url = set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+		$current_url = set_url_scheme( site_url($_SERVER['REQUEST_URI']) );
 		$current_url = remove_query_arg( 'paged', $current_url );
 
 		if ( isset( $_GET['orderby'] ) )


### PR DESCRIPTION
When I use pagination function in ``class-wp-list-table.php``, ``$_SERVER['HTTP_HOST']`` returns incorrect url. I guess it is because infrastructure for wordpress I'm using is with load balancer. So ``$_SERVER['HTTP_HOST']`` get the url of load balancer.
I fixed it by replacing that into ``site_url()`` which is wordpress function to get the site url. I think it is better way to do that.