### PR TITLE
Increasing memory limit in default-constants.php

### DIFF
--- a/wp-includes/default-constants.php
+++ b/wp-includes/default-constants.php
@@ -20,7 +20,7 @@ function wp_initial_constants() {
 		if( is_multisite() ) {
 			define('WP_MEMORY_LIMIT', '64M');
 		} else {
-			define('WP_MEMORY_LIMIT', '40M');
+			define('WP_MEMORY_LIMIT', '64M');
 		}
 	}
 


### PR DESCRIPTION
Wocommerce recomended at least 64.