### PR TITLE
fix: upload folder not set correctly

### DIFF
--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -1801,6 +1801,8 @@ function wp_upload_dir( $time = null ) {
 			else
 				$dir = ABSPATH . UPLOADS;
 			$url = trailingslashit( $siteurl ) . 'files';
+        } elseif (defined( 'BLOGUPLOADDIR' )) {
+			$dir = untrailingslashit( BLOGUPLOADDIR );
 		}
 	}
 


### PR DESCRIPTION
When blog is switched and still using old multisite upload folders, upload
directory is not set correctly, which makes functions like
wp_get_attachment_image_src() return the wrong url.