### PR TITLE
Error wp-includes/post.php  in _get_custom_object_labels

### DIFF
--- a/wp-includes/post.php
+++ b/wp-includes/post.php
@@ -1714,6 +1714,7 @@ function _get_custom_object_labels( $object, $nohier_vs_hier_defaults ) {
 		$defaults[$key] = $object->hierarchical ? $value[1] : $value[0];
 	}
 	$labels = array_merge( $defaults, $object->labels );
+	$object->labels = (object)$object->labels;
 	return (object) $labels;
 }
 


### PR DESCRIPTION
When you use construction like this:
$post_type_obj = get_post_type_object ( $post_type );
$labels = get_post_type_labels($post_type_obj)
.............................
global $wp_post_types will be rewrite and property $wp_post_types[$post_type]->labels will be an array and must be object.
It is critical for wp-admin/includes/post.php $sendback_text = get_post_type_object( $post->post_type )->labels->all_items; (~line 1250)