### PR TITLE
robots noindex, nofollow for wp_die()

### DIFF
--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -2523,6 +2523,7 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<meta name="viewport" content="width=device-width">
+	<meta name="robots" content="noindex,nofollow" />
 	<title><?php echo $title ?></title>
 	<style type="text/css">
 		html {


### PR DESCRIPTION
It would be useful to have this on wp_die() page template. wp_die() could be used as simple maintenance plugin and this would be very helpful to have this meta attribute set to prevent errors in e.g. google analytics. 