### PR TITLE
Avoid PHP 4 warnings for PHP 5 users

### DIFF
--- a/wp-includes/widgets.php
+++ b/wp-includes/widgets.php
@@ -173,7 +173,9 @@ class WP_Widget {
 	 * @param array  $control_options
 	 */
 	public function WP_Widget( $id_base, $name, $widget_options = array(), $control_options = array() ) {
-		_deprecated_constructor( 'WP_Widget', '4.3.0' );
+		if (version_compare(phpversion(), '5.0.0', '<')) {
+		    _deprecated_constructor( 'WP_Widget', '4.3.0' );
+		}
 		WP_Widget::__construct( $id_base, $name, $widget_options, $control_options );
 	}
 


### PR DESCRIPTION
No more warnings or errors for the right use of $this->WP_Widget to create a new object of the class WP_Widget with PHP 5. 
The old helper constructor method WP_Widget() is only for PHP 4, so only those guys should get a deprecated warning/error message!!
!!Please check all implementations of _deprecated_constructor in the methods that are named like the class name inside the wordpress project!!
$php_version is not working at this place!