### PR TITLE
Failed to set charset

### DIFF
--- a/wp-includes/wp-db.php
+++ b/wp-includes/wp-db.php
@@ -778,9 +778,7 @@ class wpdb {
 			$collate = $this->collate;
 		if ( $this->has_cap( 'collation' ) && ! empty( $charset ) ) {
 			if ( $this->use_mysqli ) {
-				if ( function_exists( 'mysqli_set_charset' ) && $this->has_cap( 'set_charset' ) ) {
-					mysqli_set_charset( $dbh, $charset );
-				} else {
+				if (!( function_exists( 'mysqli_set_charset' ) && $this->has_cap( 'set_charset' ) && mysqli_set_charset( $dbh, $charset ) )) {
 					$query = $this->prepare( 'SET NAMES %s', $charset );
 					if ( ! empty( $collate ) )
 						$query .= $this->prepare( ' COLLATE %s', $collate );


### PR DESCRIPTION
mysqli_set_charset might fail to set up charset (like in my case).
Wordpress should fallback to old method.