### PR TITLE
Urgent, using is_callable() instead of is_null()

### DIFF
--- a/wp-includes/plugin.php
+++ b/wp-includes/plugin.php
@@ -521,7 +521,7 @@ function do_action($tag, $arg = '') {
 
 	do {
 		foreach ( (array) current($wp_filter[$tag]) as $the_ )
-			if ( !is_null($the_['function']) )
+			if ( is_callable($the_['function']) )
 				call_user_func_array($the_['function'], array_slice($args, 0, (int) $the_['accepted_args']));
 
 	} while ( next($wp_filter[$tag]) !== false );


### PR DESCRIPTION
in some cases i noticed errors due to some bad plugins, after searching in the `wp-includes/plugin.php` file, i found that you are using `is_null()` not `is_callable()`
and i don't know why, the function may not be null but also not a function .