### PR TITLE
Changed getchmod() function to abstract instead of returning '777';

### DIFF
--- a/wp-admin/includes/class-wp-filesystem-base.php
+++ b/wp-admin/includes/class-wp-filesystem-base.php
@@ -374,9 +374,7 @@ class WP_Filesystem_Base {
 	 * @param string $file
 	 * @return string the last 3 characters of the octal number
 	 */
-	public function getchmod( $file ) {
-		return '777';
-	}
+	abstract public function getchmod( $file );
 
 	/**
 	 * Convert *nix-style file permissions to a octal number.


### PR DESCRIPTION
Body of this function is misleading. Looks that child classes rewrites it anyway.