### PR TITLE
Update mistake on retrieve_password do action

### DIFF
--- a/wp-includes/user.php
+++ b/wp-includes/user.php
@@ -1953,7 +1953,7 @@ function get_password_reset_key( $user ) {
 	 *
 	 * @param string $user_login The user login name.
 	 */
-	do_action( 'retreive_password', $user->user_login );
+	do_action( 'retrieve_password', $user->user_login );
 
 	/**
 	 * Fires before a new password is retrieved.


### PR DESCRIPTION
A little mistake that can break some plugins that use this action to customize the reset password actions.