### PR TITLE
improvement for: post_parent__not_in. could not use post__not_in as a…

### DIFF
--- a/wp-includes/query.php
+++ b/wp-includes/query.php
@@ -2769,7 +2769,7 @@ class WP_Query {
 			$post_parent__in = implode( ',', array_map( 'absint', $q['post_parent__in'] ) );
 			$where .= " AND {$wpdb->posts}.post_parent IN ($post_parent__in)";
 		} elseif ( $q['post_parent__not_in'] ) {
-			$post_parent__not_in = implode( ',',  array_map( 'absint', $q['post_parent__not_in'] ) );
+			$post_parent__not_in = implode( ',',  array_map( 'absint', is_string( $q['post_parent__not_in'] ) ? explode( ',', $q['post_parent__not_in'] ) : $q['post_parent__not_in'] ) );
 			$where .= " AND {$wpdb->posts}.post_parent NOT IN ($post_parent__not_in)";
 		}
 


### PR DESCRIPTION
Improvement for: `post_parent__not_in` in line **2772**. could not use `post__not_in` as a parameter in a string.

Example:
_if the following query is run it does not work without the improvement_
`query_posts( 'post__not_in=2&post_status=publish&posts_per_page=15&paged=1' );`

Greetings from Mexico.

**Best regards**
Gustavo Martínez