### PR TITLE
[FEATURE] Give users control on the term redirect

### DIFF
--- a/wp-admin/edit-tags.php
+++ b/wp-admin/edit-tags.php
@@ -205,7 +205,7 @@ if ( $location ) {
 	if ( ! empty( $_REQUEST['paged'] ) ) {
 		$location = add_query_arg( 'paged', (int) $_REQUEST['paged'], $location );
 	}
-	wp_redirect( $location );
+	wp_redirect( apply_filters( 'redirect_term_location', $location, $tax ) );
 	exit;
 }
 


### PR DESCRIPTION
This is a copy of an existing method inside the post.php

`wp_redirect( apply_filters( 'redirect_post_location', $location, $post_id ) );`