### PR TITLE
[FEATURE] Give users control on the term redirect

### DIFF
--- a/wp-admin/edit-tags.php
+++ b/wp-admin/edit-tags.php
@@ -205,7 +205,15 @@ if ( $location ) {
 	if ( ! empty( $_REQUEST['paged'] ) ) {
 		$location = add_query_arg( 'paged', (int) $_REQUEST['paged'], $location );
 	}
-	wp_redirect( $location );
+	/**
+	 * Filter the taxonomy redirect destination URL.
+	 *
+	 * @since 4.5.0
+	 * 
+	 * @param string $location  The destination URL.
+	 * @param object $tax       The taxonomy object.
+	 */
+	wp_redirect( apply_filters( 'redirect_term_location', $location, $tax ) );
 	exit;
 }
 


### PR DESCRIPTION
This is a copy of an existing method inside the post.php
wp_redirect( apply_filters( 'redirect_post_location', $location, $post_id ) );

Ticket about this feature is going on over here:

https://core.trac.wordpress.org/ticket/36367#ticket