### PR TITLE
Spelling correction in line 16. *Theme*

### DIFF
--- a/wp-admin/includes/class-wp-theme-install-list-table.php
+++ b/wp-admin/includes/class-wp-theme-install-list-table.php
@@ -13,7 +13,7 @@
  * @since 3.1.0
  * @access private
  *
- * @see WP_Thenes_List_Table
+ * @see WP_Themes_List_Table
  */
 class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 


### PR DESCRIPTION
Corrected 'Thene' to 'Theme' in comment at line 16, of file : wp-admin/includes/class-wp-theme-install-list-table.php

Corrected '@see WP_Thenes_List_Table' to '@see WP_Themes_List_Table'