### PR TITLE
check if widget class defined in register function

### DIFF
--- a/wp-includes/class-wp-widget-factory.php
+++ b/wp-includes/class-wp-widget-factory.php
@@ -102,7 +102,9 @@ class WP_Widget_Factory {
 		if ( $widget instanceof WP_Widget ) {
 			$this->widgets[ $this->hash_object( $widget ) ] = $widget;
 		} else {
-			$this->widgets[ $widget ] = new $widget();
+			if(class_exists($widget_class)) {
+				$this->widgets[ $widget ] = new $widget();
+			}
 		}
 	}
 


### PR DESCRIPTION
This change makes debugging broken widgets a lot less painful -- in case of errors in widgets this will allow the site to load and the developer to see the error messages instead of just blowing up with the ambiguous error message "Class not defined".
