### PR TITLE
Filter `add_editor_style()` early exit condition

### DIFF
--- a/wp-includes/theme.php
+++ b/wp-includes/theme.php
@@ -1425,8 +1425,9 @@ body.custom-background { <?php echo trim( $style ); ?> }
 function add_editor_style( $stylesheet = 'editor-style.css' ) {
 	add_theme_support( 'editor-style' );
 
-	if ( ! is_admin() )
+	if ( (bool) apply_filters( 'disable_editor_style', ! is_admin() ) ) {
 		return;
+	}
 
 	global $editor_styles;
 	$editor_styles = (array) $editor_styles;


### PR DESCRIPTION
Adding a filter to allow modifying a condition when editor stylesheet is not added.

By default the editor stylesheets are not added on frontend. Though, some plugins might use the editor on frontend too, so it would be desirable to allow editor stylesheets there. We are not forcing this option here, just providing a way to do so.

@todo Maybe consider removing the conditional altogether?