### PR TITLE
Send empty array to wp_signon to mitigate error in php 7.1.0 alpha 1

### DIFF
--- a/wp-login.php
+++ b/wp-login.php
@@ -790,7 +790,7 @@ default:
 
 	$reauth = empty($_REQUEST['reauth']) ? false : true;
 
-	$user = wp_signon( '', $secure_cookie );
+	$user = wp_signon( array(), $secure_cookie );
 
 	if ( empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
 		if ( headers_sent() ) {


### PR DESCRIPTION
PHP 7.1.0 was just released and they seems to have changed how arrays and strings behave.

The function wp_signon expects an array and is being called with a string and that fails with : 
Warning: Illegal string offset 'user_login' in