### PR TITLE
Fix for cannot use object WP_Error as array error

### DIFF
--- a/wp-admin/user-new.php
+++ b/wp-admin/user-new.php
@@ -150,8 +150,12 @@ Please click the following link to confirm the invite:
 				$new_user = wpmu_activate_signup( $key );
 				if ( ! is_wp_error( $new_user ) ) {
 					$redirect = add_query_arg( array( 'update' => 'addnoconfirmation' ), 'user-new.php' );
+				} else if ( isset( $new_user->errors['already_active'] ) && ( $user = get_user_by( 'email', $new_user_email ) ) ) {
+					$redirect = add_query_arg( array( 'update' => 'addnoconfirmation', 'user_id' => $user->ID ), 'user-new.php' );
 				} else {
-					$redirect = add_query_arg( array( 'update' => 'addnoconfirmation', 'user_id' => $new_user['user_id'] ), 'user-new.php' );
+					$error_message = $new_user->get_error_message();
+					$location = admin_url( 'user-new.php');
+					wp_die( $error_message . ' <a href="' . $location . '">Return to add new user page.</a>.');
 				}
 			} else {
 				$redirect = add_query_arg( array('update' => 'newuserconfirmation'), 'user-new.php' );


### PR DESCRIPTION
When wpmu_activate_signup() returns a WP_Error on line 147, $new_user['user_id'] throws "Cannot use object of type WP_Error as array". When the WP_Error object has 'already_active' set, then we know that the user has been created, and can access the user_id via the user's email.

Addresses: https://core.trac.wordpress.org/ticket/37223
