### PR TITLE
XML-RPC: getPosts: Allow for negative 'number' option

### DIFF
--- a/wp-includes/class-wp-xmlrpc-server.php
+++ b/wp-includes/class-wp-xmlrpc-server.php
@@ -1803,7 +1803,7 @@ class wp_xmlrpc_server extends IXR_Server {
 			$query['post_status'] = $filter['post_status'];
 
 		if ( isset( $filter['number'] ) )
-			$query['numberposts'] = absint( $filter['number'] );
+			$query['numberposts'] = int( $filter['number'] );
 
 		if ( isset( $filter['offset'] ) )
 			$query['offset'] = absint( $filter['offset'] );


### PR DESCRIPTION
It is currently not possible to request all posts by setting `number` to `-1` when using `getPosts`.