### PR TITLE
Update load.php - is_ssl() to work under ELB

### DIFF
--- a/wp-includes/load.php
+++ b/wp-includes/load.php
@@ -971,7 +971,9 @@ function is_ssl() {
 		}
 	} elseif ( isset($_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
 		return true;
-	}
+	} elseif ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https' ) {
+            	return true;
+        }
 	return false;
 }
 


### PR DESCRIPTION
When under Load Balancers, specifically under AWS ELB, the is_ssl function goes in an infinite redirect loop - when reaching it by https.
This fix will recognize if the call is forwarded and under https so to normalize the execution.