### PR TITLE
Whitespace causing issues in media.php

### DIFF
--- a/wp-admin/includes/media.php
+++ b/wp-admin/includes/media.php
@@ -1497,8 +1497,8 @@ function get_media_item( $attachment_id, $args = null ) {
 			 <a href='#' class='button' onclick=\"this.parentNode.style.display='none';return false;\">" . __( 'Cancel' ) . "</a>
 			 </div>";
 		} else {
-			$delete = "<a href='" . wp_nonce_url( "post.php?action=trash&amp;post=$attachment_id", 'trash-post_' . $attachment_id ) . "' id='del[$attachment_id]' class='delete'>" . __( 'Move to Trash' ) . "</a>
-			<a href='" . wp_nonce_url( "post.php?action=untrash&amp;post=$attachment_id", 'untrash-post_' . $attachment_id ) . "' id='undo[$attachment_id]' class='undo hidden'>" . __( 'Undo' ) . "</a>";
+			$delete = "<a href='" . wp_nonce_url( "post.php?action=trash&amp;post=$attachment_id", 'trash-post_' . $attachment_id ) . "' id='del[$attachment_id]' class='delete'>" . __( 'Move to Trash' ) . "</a>"
+			."<a href='" . wp_nonce_url( "post.php?action=untrash&amp;post=$attachment_id", 'untrash-post_' . $attachment_id ) . "' id='undo[$attachment_id]' class='undo hidden'>" . __( 'Undo' ) . "</a>";
 		}
 	} else {
 		$delete = '';


### PR DESCRIPTION
Whitespace causing issues - Parse error: syntax error, unexpected ''' (T_ENCAPSED_AND_WHITESPACE) in *******/wp-admin/includes/media.php on line 1500

https://wordpress.org/support/topic/cant-access-wp-admin-after-move-to-another-host/
