### PR TITLE
Fixing issue with tax_query => [] not working in WP_Query()

### DIFF
--- a/wp-includes/query.php
+++ b/wp-includes/query.php
@@ -1891,7 +1891,7 @@ class WP_Query {
 	 */
 	public function parse_tax_query( &$q ) {
 		if ( ! empty( $q['tax_query'] ) && is_array( $q['tax_query'] ) ) {
-			$tax_query = $q['tax_query'];
+			$tax_query[] = $q['tax_query'];
 		} else {
 			$tax_query = array();
 		}


### PR DESCRIPTION
Using `tax_query` in the `$args` parameter of `WP_Query($args)` wasn't working. The syntax is as per https://codex.wordpress.org/Class_Reference/WP_Query#Taxonomy_Parameters

So this code wasn't working (it was ignoring the tax_query all together):

```
$q = new \WP_Query([
                             'post_type' => 'business',
                             'tax_query' => [
                                 'taxonomy' => 'business_category',
                                 'field'    => 'slug',
                                 'terms'    => 'american'
                             ]
                     ]);
```

so it would just return everything in the _business_ post type.