### PR TITLE
Plugin details modal tabs fix

### DIFF
--- a/wp-admin/css/common.css
+++ b/wp-admin/css/common.css
@@ -2588,8 +2588,6 @@ div.action-links {
 	display: inline-block;
 	padding: 9px 10px;
 	margin: 0;
-	height: 18px;
-	line-height: 18px;
 	font-size: 14px;
 	text-decoration: none;
 	-webkit-transition: none;


### PR DESCRIPTION
Remove hardcoded height and line height for plugin details modal tabs, as the conflict with the padding declaration.
