### PR TITLE
Add $options in array to merge without errors

### DIFF
--- a/wp-includes/widgets.php
+++ b/wp-includes/widgets.php
@@ -538,7 +538,7 @@ function _register_widget_update_callback( $id_base, $update_callback, $options 
 		'params' => array_slice(func_get_args(), 3)
 	);
 
-	$widget = array_merge($widget, $options);
+	$widget = array_merge($widget, array($options));
 	$wp_registered_widget_updates[$id_base] = $widget;
 }
 


### PR DESCRIPTION
When I was try create a wordpress plugin widget, this error was appeared:

Warning: array_merge(): Argument #2 is not an array in /var/www/html/wordpress/wp-includes/widgets.php on line 541

I think this can solve.