### PR TITLE
Disable PHP in /wp-content/ 

### DIFF
--- a/wp-content/.htaccess
+++ b/wp-content/.htaccess
@@ -1,0 +1,3 @@
+<Files *.php>
+deny from all
+</Files>


### PR DESCRIPTION
security reasons