### PR TITLE
Apply PHP Coding Standards and Remove Empty Lines

### DIFF
--- a/wp-admin/admin.php
+++ b/wp-admin/admin.php
@@ -94,9 +94,6 @@ $time_format = __( 'g:i a' );
 
 wp_enqueue_script( 'common' );
 
-
-
-
 /**
  * $pagenow is set in vars.php
  * $wp_importers is sometimes set in wp-admin/includes/import.php

--- a/wp-admin/custom-header.php
+++ b/wp-admin/custom-header.php
@@ -238,7 +238,7 @@ class Custom_Image_Header {
 	public function process_default_headers() {
 		global $_wp_default_headers;
 
-		if ( !isset($_wp_default_headers) )
+		if ( ! isset($_wp_default_headers) )
 			return;
 
 		if ( ! empty( $this->default_headers ) ) {


### PR DESCRIPTION
Adjust code for readability adding space to condition.

Please click this link for the PHP Coding Standard for WP and find Clever Code # portion. 
https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/

I have also remove an 3 line of empty codes. 



