### PR TITLE
Removed angle brackets from Lost Password email

### DIFF
--- a/wp-login.php
+++ b/wp-login.php
@@ -329,7 +329,7 @@ function retrieve_password() {
 	$message .= sprintf(__('Username: %s'), $user_login) . "\r\n\r\n";
 	$message .= __('If this was a mistake, just ignore this email and nothing will happen.') . "\r\n\r\n";
 	$message .= __('To reset your password, visit the following address:') . "\r\n\r\n";
-	$message .= '<' . network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user_login), 'login') . ">\r\n";
+	$message .= network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user_login), 'login') . "\r\n";
 
 	if ( is_multisite() ) {
 		$blogname = get_network()->site_name;


### PR DESCRIPTION
Angle brackets cause undesired results in certain email clients (gmail, outlook) as they are parsed as HTML - meaning that no password reset link is shown in the email.