### PR TITLE
'wp-api' move in the `wp_head();`

### DIFF
--- a/wp-includes/script-loader.php
+++ b/wp-includes/script-loader.php
@@ -504,7 +504,7 @@ function wp_default_scripts( &$scripts ) {
 	$scripts->add( 'media-audiovideo', "/wp-includes/js/media-audiovideo$suffix.js", array( 'media-editor' ), false, 1 );
 	$scripts->add( 'mce-view', "/wp-includes/js/mce-view$suffix.js", array( 'shortcode', 'jquery', 'media-views', 'media-audiovideo' ), false, 1 );
 
-	$scripts->add( 'wp-api', "/wp-includes/js/wp-api$suffix.js", array( 'jquery', 'backbone', 'underscore' ), false, 1 );
+	$scripts->add( 'wp-api', "/wp-includes/js/wp-api$suffix.js", array( 'jquery', 'backbone', 'underscore' ), false, 0 );
 	did_action( 'init' ) && $scripts->localize( 'wp-api', 'wpApiSettings', array(
 		'root'          => esc_url_raw( get_rest_url() ),
 		'nonce'         => ( wp_installing() && ! is_multisite() ) ? '' : wp_create_nonce( 'wp_rest' ),


### PR DESCRIPTION
It's called in `wp_enqueue_script( 'wp-api' );`, and use in some JavaScript.

It inserted like this code.
```
<script type='text/javascript'>
/* <![CDATA[ */
var wpApiSettings = {"root":"http:\/\/localhost\/wp-json\/","nonce":"XXXXXXXXXX","versionString":"wp\/v2\/"};
/* ]]> */
</script>
```

But now, it is inserted in the `wp_footer();`. It should be inserted in the `wp_head();` because it might be used by read into `<head></head>` JavaScript.