### PR TITLE
Update class class-pclzip.php

### DIFF
--- a/wp-admin/includes/class-pclzip.php
+++ b/wp-admin/includes/class-pclzip.php
@@ -4205,11 +4205,16 @@
       // ----- Do the extraction (if not a folder)
       if (!(($p_entry['external']&0x00000010)==0x00000010)) {
         // ----- Look for not compressed file
-  //      if ($p_entry['compressed_size'] == $p_entry['size'])
         if ($p_entry['compression'] == 0) {
-
-          // ----- Reading the file
-          $p_string = @fread($this->zip_fd, $p_entry['compressed_size']);
+            if ($p_entry['compressed_size'] == 0){
+                // ----- Fread requires a non zero length parameter
+                // ----- Reading the file
+                $p_string = @fread($this->zip_fd, filesize($this->zipname));
+             }
+             else{
+                 // ----- Reading the file
+                 $p_string = @fread($this->zip_fd, $p_entry['compressed_size']);
+             }
         }
         else {
 


### PR DESCRIPTION
Installing a plugin results in a warning because a 0 filesize is passed to fread()


_Backtrace from warning "fread(): Length parameter must be greater than 0"_
In 
/var/www/wp-admin/includes/class-pclzip.php [line 4213] calling process_error()
/var/www/wp-admin/includes/class-pclzip.php 4213 calling fread()
/var/www/wp-admin/includes/class-pclzip.php 3518 calling privExtractFileAsString() 
/var/www/wp-admin/includes/class-pclzip.php 811 calling privExtractByRule() 
/var/www/wp-admin/includes/file.php 744 calling extract() 
/var/www/wp-admin/includes/file.php 614 calling _unzip_file_pclzip() 
/var/www/wp-admin/includes/class-wp-upgrader.php 320 calling unzip_file() 
/var/www/wp-admin/includes/class-wp-upgrader.php 728 calling unpack_package() 
/var/www/wp-admin/includes/class-plugin-upgrader.php 110 calling run() 
/var/www/wp-admin/update.php 162 calling install()_

Changed to read the filesize before passing to fread()
Tested on :
System Linux ubuntu 4.4.0-66-generic #87-Ubuntu SMP Fri Mar 3 15:29:05 UTC 2017 x86_64
PHP Version 7.0.15-0ubuntu0.16.04.4
MySQL Version 5.7.17-0ubuntu0.16.04.1

