### PR TITLE
Remove all slug accents when you copy/paste in title field

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -1512,6 +1512,8 @@ function utf8_uri_encode( $utf8_string, $length = 0 ) {
  * @return string Filtered string with replaced "nice" characters.
  */
 function remove_accents( $string ) {
+	$string = preg_replace("/[^\x01-\x7F]/", '', $string);
+	
 	if ( !preg_match('/[\x80-\xff]/', $string) )
 		return $string;
 


### PR DESCRIPTION
When you copy/paste a string with accents and a certain font from Word or Excel for example to the title field, the generated slug keep accents. So I fix this by adding a regex in the remove_accents function.