### PR TITLE
forcing installed_themes to be an array

### DIFF
--- a/wp-admin/theme-install.php
+++ b/wp-admin/theme-install.php
@@ -28,7 +28,7 @@ if ( ! is_network_admin() ) {
 }
 
 $installed_themes = search_theme_directories();
-foreach ( $installed_themes as $k => $v ) {
+foreach ( ( Array ) $installed_themes as $k => $v ) {
 	if ( false !== strpos( $k, '/' ) ) {
 		unset( $installed_themes[ $k ] );
 	}


### PR DESCRIPTION
When the wp-content/themes folder is empty, the "search_theme_directories()" returns an invalid value which can't be used on foreach. casting the value $installed_themes may prevent it.