### PR TITLE
One space too much.

### DIFF
--- a/wp-includes/class-walker-nav-menu.php
+++ b/wp-includes/class-walker-nav-menu.php
@@ -74,7 +74,7 @@ class Walker_Nav_Menu extends Walker {
 		$class_names = join( ' ', apply_filters( 'nav_menu_submenu_css_class', $classes, $args, $depth ) );
 		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 
-		$output .= "{$n}{$indent}<ul $class_names>{$n}";
+		$output .= "{$n}{$indent}<ul{$class_names}>{$n}";
 	}
 
 	/**


### PR DESCRIPTION
On some themes menu is broken.
For example Hotelbook smthemes (https://smthemes.com/hotelbook/)