### PR TITLE
Custom admin page’s hook suffix translated

### DIFF
--- a/wp-admin/includes/plugin.php
+++ b/wp-admin/includes/plugin.php
@@ -1078,7 +1078,7 @@ function add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $func
 
 	$menu_slug = plugin_basename( $menu_slug );
 
-	$admin_page_hooks[$menu_slug] = sanitize_title( $menu_slug );
+	$admin_page_hooks[$menu_slug] = $menu_slug;
 
 	$hookname = get_plugin_page_hookname( $menu_slug, '' );
 

--- a/wp-admin/includes/plugin.php
+++ b/wp-admin/includes/plugin.php
@@ -1078,7 +1078,7 @@ function add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $func
 
 	$menu_slug = plugin_basename( $menu_slug );
 
-	$admin_page_hooks[$menu_slug] = sanitize_title( $menu_title );
+	$admin_page_hooks[$menu_slug] = sanitize_title( $menu_slug );
 
 	$hookname = get_plugin_page_hookname( $menu_slug, '' );
 


### PR DESCRIPTION
Hook name changed due to translated. Custom admin page’s hook suffix added by plugins might get translated if your plugin file has translation option and .mo file has the text of your custom menu title. It should use '$menu_slug' than '$menu_title' which doesn't change.