### PR TITLE
Fix three dots in popup details of plugin title installed on "Check details of Version X.X.X"

### DIFF
--- a/wp-admin/css/common.css
+++ b/wp-admin/css/common.css
@@ -2490,7 +2490,7 @@ div.action-links {
 }
 
 #plugin-information-title.with-banner h2 {
-	position: relative;
+	position: absolute;
 	font-family: "Helvetica Neue", sans-serif;
 	display: inline-block;
 	font-size: 30px;


### PR DESCRIPTION
Can check this in /wp-admin/update-core.php and click in any plugin to update on "Check details of version X.X.X"
And the title of the plugin is only three dots.
WordPress Version 4.7.5