### PR TITLE
Return http status as 409 on setup error

### DIFF
--- a/wp-admin/setup-config.php
+++ b/wp-admin/setup-config.php
@@ -60,7 +60,7 @@ if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 			__( 'The file %1$s already exists. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href="%2$s">installing now</a>.' ),
 			'<code>wp-config.php</code>',
 			'install.php'
-		) . '</p>'
+		) . '</p>', '', array('response' => 409)
 	);
 }
 
@@ -71,7 +71,7 @@ if ( @file_exists( ABSPATH . '../wp-config.php' ) && ! @file_exists( ABSPATH . '
 			__( 'The file %1$s already exists one level above your WordPress installation. If you need to reset any of the configuration items in this file, please delete it first. You may try <a href="%2$s">installing now</a>.' ),
 			'<code>wp-config.php</code>',
 			'install.php'
-		) . '</p>'
+		) . '</p>', '', array('response' => 409)
 	);
 }
 


### PR DESCRIPTION
This change is specify http-response-status as 409 when wp-config.php already exists on setup.

```sh
$ curl -F 'dbname=test' -F 'uname=test' -F 'pwd=secret' -F 'dbhost=localhost' -F 'prefix=wp_' \
  http://example.com/wp-admin/setup-config.php?step=2 -o /dev/null -w '%{http_code}\n' -s
200

# current
$ curl -X POST http://example.com/wp-admin/setup-config.php?step=2 -o /dev/null -w '%{http_code}\n' -s
500

# new
$ curl -X POST http://example.com/wp-admin/setup-config.php?step=2 -o /dev/null -w '%{http_code}\n' -s
409
```