### PR TITLE
Avoid PHP 7.2 warning in class-IXR-server.php

### DIFF
--- a/wp-includes/IXR/class-IXR-server.php
+++ b/wp-includes/IXR/class-IXR-server.php
@@ -98,7 +98,7 @@ EOD;
         $method = $this->callbacks[$methodname];
 
         // Perform the callback and send the response
-        if (count($args) == 1) {
+        if (null !== $args && count($args) == 1) {
             // If only one parameter just send that instead of the whole array
             $args = $args[0];
         }


### PR DESCRIPTION
Avoid warning: Got error 'PHP message: PHP Warning:  count(): Parameter must be an array or an object that implements Countable in wp-includes/IXR/class-IXR-server.php on line 101\n' when running on PHP 7.2