### PR TITLE
Switch wp_get_current_user() to check login status

### DIFF
--- a/wp-includes/pluggable.php
+++ b/wp-includes/pluggable.php
@@ -1034,7 +1034,10 @@ if ( ! function_exists( 'auth_redirect' ) ) :
 		 */
 		$scheme = apply_filters( 'auth_redirect_scheme', '' );
 
-		if ( $user_id = wp_validate_auth_cookie( '', $scheme ) ) {
+		$current_user = wp_get_current_user();
+	        $user_id = (int) $current_user->ID;
+
+	        if ( $user_id ) {
 			/**
 			 * Fires before the authentication redirect.
 			 *


### PR DESCRIPTION
Switch to wp_get_current_user()  to check login status seems better than wp_validate_auth_cookie(), cause user could add filter : determine_current_user to check more.