### PR TITLE
Inserting Default filters in method wp_delete_file to protecting core folders

### DIFF
--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -5762,8 +5762,10 @@ function wp_delete_file( $file, $directories_unblock = array() ) {
 	 *
 	 * @since 2.1.0
 	 * @param string $file Path to the file to delete.
+	 * @param array $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
+	 *                                   and WP_INCLUDE_DIR.
 	 */
-	$delete = apply_filters( 'wp_delete_file', $file );
+	$delete = apply_filters( 'wp_delete_file', $file, $directories_unblock );
 	if ( ! empty( $delete ) ) {
 		@unlink( $delete );
 	}

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -5736,36 +5736,43 @@ function wp_validate_boolean( $var ) {
 /**
  * Delete a file
  *
- * @since 4.9.2
+ * @since 4.2.0
+ * @since 4.7.2 Added the $unblock_directories parameter and default filters.
  *
  * @param string $file                The path to the file to delete.
- * @param array  $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
- *                                   and WP_INCLUDE_DIR.
- * @return bool Whether the param is invalidated.
+ * @param array  $unblock_directories By default path core directories are block and $unblock_directories are clear.
+ *                                    To unblock core folders you need set in array names ROOT, WP_CONTENT_DIR,
+ *                                    WP_ADMIN_DIR or WP_INCLUDE_DIR.
  */
-function wp_delete_file( $file, $directories_unblock = array() ) {
+function wp_delete_file( $file, $unblock_directories = array() ) {
 
 	// Default Filters the path of the file to delete.
-	$path_blocked['ROOT']           = rtrim( ABSPATH, '/' );
-	$path_blocked['WP_CONTENT_DIR'] = WP_CONTENT_DIR;
-	$path_blocked['WP_ADMIN_DIR']   = ABSPATH . 'wp-admin';
-	$path_blocked['WP_INCLUDE_DIR'] = realpath( ABSPATH . WPINC );
-	$path_blocked                   = array_diff_key( $path_blocked, array_flip( $directories_unblock ) );
-	$file_folder_path               = realpath( ltrim( dirname( $file ), '/' ) );
+	$path_blocked = array(
+	        'ROOT' => realpath( untrailingslashit( ABSPATH ) ), // Root path folder.
+	        'WP_CONTENT_DIR' => realpath( WP_CONTENT_DIR ), // wp-content path folder.
+	        'WP_ADMIN_DIR' => realpath( ABSPATH . 'wp-admin'), // wp-admin path folder.
+	        'WP_INCLUDE_DIR' => realpath( ABSPATH . WPINC ) // wp-incluide path folder.
+    );
 
-	if ( in_array( $file_folder_path, $path_blocked ) ) {
-		return false;
+	$path_blocked     = array_diff_key( $path_blocked, array_flip( $unblock_directories ) );
+	$file_folder_path = realpath( ltrim( dirname( $file ), DIRECTORY_SEPARATOR ) );
+
+	if ( in_array( $file_folder_path, $path_blocked, true) )  {
+		return;
 	}
 
 	/**
 	 * Filters the path of the file to delete.
 	 *
-	 * @since 4.9.2
+	 * @since 4.2.0
+	 * @since 4.7.2 Added the $unblock_directories parameter and default filters.
+     *
 	 * @param string $file                Path to the file to delete.
-	 * @param array  $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
-	 *                                   and WP_INCLUDE_DIR.
+	 * @param array  $unblock_directories By default path core directories are block and $unblock_directories are clear.
+	 *                                    To unblock core folders you need set in array names ROOT, WP_CONTENT_DIR,
+	 *                                    WP_ADMIN_DIR or WP_INCLUDE_DIR.
 	 */
-	$delete = apply_filters( 'wp_delete_file', $file, $directories_unblock );
+	$delete = apply_filters( 'wp_delete_file', $file, $unblock_directories );
 	if ( ! empty( $delete ) ) {
 		@unlink( $delete );
 	}

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -5736,7 +5736,7 @@ function wp_validate_boolean( $var ) {
 /**
  * Delete a file
  *
- * @since 4.2.0
+ * @since 4.9.2
  *
  * @param string $file The path to the file to delete.
  * @param array $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
@@ -5760,7 +5760,7 @@ function wp_delete_file( $file, $directories_unblock = array() ) {
 	/**
 	 * Filters the path of the file to delete.
 	 *
-	 * @since 2.1.0
+	 * @since 4.9.2
 	 * @param string $file Path to the file to delete.
 	 * @param array $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
 	 *                                   and WP_INCLUDE_DIR.

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -5738,8 +5738,8 @@ function wp_validate_boolean( $var ) {
  *
  * @since 4.9.2
  *
- * @param string $file The path to the file to delete.
- * @param array $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
+ * @param string $file                The path to the file to delete.
+ * @param array  $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
  *                                   and WP_INCLUDE_DIR.
  * @return bool Whether the param is invalidated.
  */
@@ -5761,8 +5761,8 @@ function wp_delete_file( $file, $directories_unblock = array() ) {
 	 * Filters the path of the file to delete.
 	 *
 	 * @since 4.9.2
-	 * @param string $file Path to the file to delete.
-	 * @param array $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
+	 * @param string $file                Path to the file to delete.
+	 * @param array  $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
 	 *                                   and WP_INCLUDE_DIR.
 	 */
 	$delete = apply_filters( 'wp_delete_file', $file, $directories_unblock );

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -5739,13 +5739,28 @@ function wp_validate_boolean( $var ) {
  * @since 4.2.0
  *
  * @param string $file The path to the file to delete.
+ * @param array $directories_unblock Are directory to unblocked. They are ROOT, WP_CONTENT_DIR, WP_ADMIN_DIR
+ *                                   and WP_INCLUDE_DIR.
+ * @return bool Whether the param is invalidated.
  */
-function wp_delete_file( $file ) {
+function wp_delete_file( $file, $directories_unblock = array() ) {
+
+	// Default Filters the path of the file to delete.
+	$path_blocked['ROOT']           = rtrim( ABSPATH, '/' );
+	$path_blocked['WP_CONTENT_DIR'] = WP_CONTENT_DIR;
+	$path_blocked['WP_ADMIN_DIR']   = ABSPATH . 'wp-admin';
+	$path_blocked['WP_INCLUDE_DIR'] = realpath( ABSPATH . WPINC );
+	$path_blocked                   = array_diff_key( $path_blocked, array_flip( $directories_unblock ) );
+	$file_folder_path               = realpath( ltrim( dirname( $file ), '/' ) );
+
+	if ( in_array( $file_folder_path, $path_blocked ) ) {
+		return false;
+	}
+
 	/**
 	 * Filters the path of the file to delete.
 	 *
 	 * @since 2.1.0
-	 *
 	 * @param string $file Path to the file to delete.
 	 */
 	$delete = apply_filters( 'wp_delete_file', $file );

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -5764,7 +5764,7 @@ function wp_delete_file( $file, $unblock_directories = array() ) {
 	/**
 	 * Filters the path of the file to delete.
 	 *
-	 * @since 4.2.0
+	 * @since 2.1.0
 	 * @since 4.7.2 Added the $unblock_directories parameter and default filters.
      *
 	 * @param string $file                Path to the file to delete.


### PR DESCRIPTION
A some days ago I opened ticket about security in method wp_delete_file in functions.php. https://core.trac.wordpress.org/ticket/42986
If community said me that is necessary the ticket are implmented.

About the that I did,
I inserted array with values with core folders with wp-content , wp-admin, wp-include (can be insert more) to don't delete files this folders.
I changed method and inserted more one array paramenter that you can unblock default parameters ( folders blocked )