### PR TITLE
The function "is_ssl" does not support sites behind CloudFlare proxy

### DIFF
--- a/wp-includes/load.php
+++ b/wp-includes/load.php
@@ -1050,6 +1050,8 @@ function is_ssl() {
 		}
 	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
 		return true;
+	} elseif ( isset($_SERVER['HTTP_X_FORWARDED_PROTO'] ) && ( 'https' == $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
If a site is behind a CloudFlare Proxy, CloudFlare does not send "HTTPS" and also don't sent the Port to "443".
Instead CloudFlare uses the Parameters "HTTP_X_FORWARDED_PROTO" and "HTTP_CF_VISITOR" is set to https.

Best regards
TobyMaxham