### PR TITLE
Added a fool-proof check to PHP_SELF regexp matching algorithm

### DIFF
--- a/wp-includes/vars.php
+++ b/wp-includes/vars.php
@@ -29,9 +29,14 @@ if ( is_admin() ) {
 	} else {
 		preg_match( '#/wp-admin/?(.*?)$#i', $_SERVER['PHP_SELF'], $self_matches );
 	}
-	$pagenow = $self_matches[1];
-	$pagenow = trim( $pagenow, '/' );
-	$pagenow = preg_replace( '#\?.*?$#', '', $pagenow );
+
+	$pagenow = '';
+	if (count($self_matches)) {
+		$pagenow = $self_matches[1];
+		$pagenow = trim( $pagenow, '/' );
+		$pagenow = preg_replace( '#\?.*?$#', '', $pagenow );
+	}
+
 	if ( '' === $pagenow || 'index' === $pagenow || 'index.php' === $pagenow ) {
 		$pagenow = 'index.php';
 	} else {


### PR DESCRIPTION
In [some environments](https://laravel.com/docs/5.5/valet) `$_SERVER['PHP_SELF']` might not include `wp-admin` which might end up with empty `$self_matches` array and cause a `Undefined offset: 1` error.