### PR TITLE
fix the bug when reset the password

### DIFF
--- a/wp-login.php
+++ b/wp-login.php
@@ -376,7 +376,7 @@ function retrieve_password() {
 	$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-	$message .= '<' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . ">\r\n";
+	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . "\r\n";
 
 	/* translators: Password reset email subject. %s: Site name */
 	$title = sprintf( __( '[%s] Password Reset' ), $site_name );


### PR DESCRIPTION
When we reset the password, wordpress will send the reset password link to us via email. But when we clicked the link in the email it would show the message:"Your password reset link appears to be invalid. Please request a new link below."
I deleted the angle brackets and everything turn ok.