### PR TITLE
Update class-wp-filesystem-ssh2.php

### DIFF
--- a/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -189,7 +189,7 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 		if ( '/' === $path ) {
 			$path = '/./';
 		}
-		return 'ssh2.sftp://' . $this->sftp_link . '/' . ltrim( $path, '/' );
+		return 'ssh2.sftp://' . (int)$this->sftp_link . '/' . ltrim( $path, '/' );
 	}
 
 	/**


### PR DESCRIPTION
$this->sftp_link needs a casting otherwise request fails and gives empty response to client.
Refer to http://php.net/manual/tr/function.ssh2-sftp.php#121200