### PR TITLE
Password reset email copy change

### DIFF
--- a/wp-login.php
+++ b/wp-login.php
@@ -376,7 +376,7 @@ function retrieve_password() {
 	$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-	$message .= '<' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . ">\r\n";
+	$message .= '(' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . ")\r\n";
 
 	/* translators: Password reset email subject. %s: Site name */
 	$title = sprintf( __( '[%s] Password Reset' ), $site_name );


### PR DESCRIPTION
When emails are configured to send as HTML (eg. with Postmark. AWS SES). Password reset link is invisible since it becomes a HTML tag when wrapped with < >. Converting them to ( ) is a good workaround. so this will work on both PlainText and HTML modes.