### PR TITLE
Use auto instead of a fixed width.

### DIFF
--- a/wp-admin/includes/class-wp-internal-pointers.php
+++ b/wp-admin/includes/class-wp-internal-pointers.php
@@ -183,7 +183,7 @@ final class WP_Internal_Pointers {
 			'content'  => $content,
 			'position' => $position,
 			'pointerClass' => 'wp-pointer arrow-bottom',
-			'pointerWidth' => 420,
+			'pointerWidth' => auto,
 		);
 		self::print_js( 'wp496_privacy', '#menu-tools', $js_args );
 	}


### PR DESCRIPTION
Better alignment for all the different languages used by WordPress.