### PR TITLE
Fix for '/usr/share/wordpress/wp-includes/plugin.php on line 658\nPHP…

### DIFF
--- a/wp-includes/plugin.php
+++ b/wp-includes/plugin.php
@@ -671,7 +671,7 @@ function plugin_basename( $file ) {
 
 	arsort( $wp_plugin_paths );
 	foreach ( $wp_plugin_paths as $dir => $realdir ) {
-		if ( strpos( $file, $realdir ) === 0 ) {
+		if ( !empty($realdir) && strpos( $file, $realdir ) === 0 ) {
 			$file = $dir . substr( $file, strlen( $realdir ) );
 		}
 	}


### PR DESCRIPTION
… message: PHP Warning:  strpos(): Empty needle in '. Line no mismatch accounted for.

Signed-off-by: Me <corbolais@gmail.com>