### PR TITLE
Resolve Wordpress asking for FTP credentials

### DIFF
--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -79,6 +79,9 @@ $table_prefix = 'wp_';
  */
 define( 'WP_DEBUG', false );
 
+// Hack to solve wordpress asking you for ftp credentials. Uncomment the line below:
+// define( 'FS_METHOD', 'direct' );
+
 /* That's all, stop editing! Happy blogging. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
To help people who experience Wordpress asking for FTP credentials when using localhost or a dedicated server. This is very cumbersome and makes people despair thinking that their system has crashed. Most of the time most guys do not know the ftp credentials to use. 