### PR TITLE
Update remove_menu_page()

### DIFF
--- a/wp-admin/includes/plugin.php
+++ b/wp-admin/includes/plugin.php
@@ -1556,11 +1556,12 @@ function add_comments_page( $page_title, $menu_title, $capability, $menu_slug, $
  */
 function remove_menu_page( $menu_slug ) {
 	global $menu;
-
-	foreach ( $menu as $i => $item ) {
-		if ( $menu_slug == $item[2] ) {
-			unset( $menu[ $i ] );
-			return $item;
+	if(isset($menu) && !is_null($menu)){
+		foreach ( $menu as $i => $item ) {
+			if ( $menu_slug == $item[2] ) {
+				unset( $menu[ $i ] );
+				return $item;
+			}
 		}
 	}
 


### PR DESCRIPTION
it is common to happen to remove some menus from the administrative part of wordpress, I had to do this and I discovered that
*"remove_menu_page(): E_WARNING: Invalid argument supplied for foreach()"*