### PR TITLE
Added native support for LaTeX files

### DIFF
--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -2740,6 +2740,7 @@ function wp_get_mime_types() {
 			'3g2|3gp2'                     => 'video/3gpp2', // Can also be audio
 			// Text formats.
 			'txt|asc|c|cc|h|srt'           => 'text/plain',
+			'tex'                          => 'text/x-tex',
 			'csv'                          => 'text/csv',
 			'tsv'                          => 'text/tab-separated-values',
 			'ics'                          => 'text/calendar',


### PR DESCRIPTION
LaTeX documents are very commonly used by academics. And many LaTeX templates are shared via conference sites powerd by Wordpress. And although there are a lot of plugins that can supposedly extend WP with the ability to upload .tex files to the server, most of them do not work at all. Native support is much more convenient and much safer to use and above all - it saves a lot of time, wasted on finding the right plugin, responsible for such a simple thing...