### PR TITLE
Cleanup index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,4 +14,4 @@
 define( 'WP_USE_THEMES', true );
 
 /** Loads the WordPress Environment and Template */
-require( dirname( __FILE__ ) . '/wp-blog-header.php' );
+require( __DIR__ . '/wp-blog-header.php' );


### PR DESCRIPTION
Since now PHP will require 5.6 as minimum (and not 5.2 anymore), we can safely get rid of dirname() and __FILE__