### PR TITLE
 fixed is_ssl() return value

### DIFF
--- a/wp-includes/load.php
+++ b/wp-includes/load.php
@@ -1272,6 +1272,8 @@ function is_ssl() {
 		}
 	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
 		return true;
+	} elseif ( isset( $_SERVER['HTTP_X-FORWARDED-PROTO'] ) && ( 'https' == strtolower( $_SERVER['HTTP_X-FORWARDED-PROTO'] ) ) ) {
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
Wordpress web server uses port 80 for HTTP, Cloud Services  uses SLB(Server Load Balancer) to supply port 443 for HTTPS while proxying web server http port 80. In the case, is_ssl() will return false, and get_template_directory_uri() will return incorrect URI. In order to fix it, we need to check SLB config 'use HTTP Head X-Forwarded-Proto to forward SLB protocol' to get $_SERVER['HTTP_X-FORWARDED-PROTO'] as 'https'.