### PR TITLE
Update get_template_part() function

### DIFF
--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -164,6 +164,8 @@ function get_template_part( $slug, $name = null ) {
 	 * @param string[] $templates Array of template files to search for, in order.
 	 */
 	do_action( 'get_template_part', $slug, $name, $templates );
+	
+	$templates = add_filter( 'get_template_part', $slug, $name, $templates );
 
 	locate_template( $templates, true, false );
 }


### PR DESCRIPTION
I think it would be good to add the ability to programmatically override the output of posts in the loop without interfering with the theme files ( for example, archive.php and others ). This will allow you to change the display of posts through plugins.
For example. To adapt the theme to work with Woocommerce, you need to edit the theme code. For users, this is sometimes very difficult.