### PR TITLE
Compatibility for digitalocean Managed Databases

### DIFF
--- a/wp-includes/wp-db.php
+++ b/wp-includes/wp-db.php
@@ -577,6 +577,7 @@ class wpdb {
 		'STRICT_TRANS_TABLES',
 		'STRICT_ALL_TABLES',
 		'TRADITIONAL',
+		'ANSI',
 	);
 
 	/**


### PR DESCRIPTION
In order to get WordPress work with Managed Databases which are by default with 'ANSI' mode, I had to add it to incompatible_modes. Otherwise I had errors like:
Error Code: 3065. Expression #1 of ORDER BY clause is not in SELECT list, references column 'xxx.wp_termmeta.meta_value' which is not in SELECT list; this is incompatible with DISTINCT