### PR TITLE
Check if the element exists before add method

### DIFF
--- a/wp-admin/js/tags-suggest.js
+++ b/wp-admin/js/tags-suggest.js
@@ -144,15 +144,18 @@
 			}
 		}, options );
 
-		$element.on( 'keydown', function() {
+		var elementAutocomplete = $element.on( 'keydown', function() {
 			$element.removeAttr( 'aria-activedescendant' );
 		} )
-		.autocomplete( options )
-		.autocomplete( 'instance' )._renderItem = function( ul, item ) {
-			return $( '<li role="option" id="wp-tags-autocomplete-' + item.id + '">' )
-				.text( item.name )
-				.appendTo( ul );
-		};
+		.autocomplete( options );
+		// If there is a element, so apply the autocomplete
+		if ( elementAutocomplete.length) {
+			elementAutocomplete.autocomplete( 'instance' )._renderItem = function( ul, item ) {
+				return $( '<li role="option" id="wp-tags-autocomplete-' + item.id + '">' )
+					.text( item.name )
+					.appendTo( ul );
+			};
+		}
 
 		$element.attr( {
 			'role': 'combobox',


### PR DESCRIPTION
In some case, the "Quick Edit" link call the "wpTagsSuggest" plugin twice.
In the first time, there is a $element but not in the second time, it throws an error "Uncaught TypeError: Cannot set property '_renderItem' of undefined"
This simple modification, avoid that error without any collateral effect