### PR TITLE
Removed default -scaled suffix filename path on insert of image

### DIFF
--- a/wp-admin/includes/image.php
+++ b/wp-admin/includes/image.php
@@ -293,7 +293,7 @@ function wp_create_image_subsizes( $file, $attachment_id ) {
 			if ( ! is_wp_error( $resized ) ) {
 				// Append "-scaled" to the image file name. It will look like "my_image-scaled.jpg".
 				// This doesn't affect the sub-sizes names as they are generated from the original image (for best quality).
-				$saved = $editor->save( $editor->generate_filename( 'scaled' ) );
+				$saved = $editor->save( $editor->generate_filename() );
 
 				if ( ! is_wp_error( $saved ) ) {
 					$image_meta = _wp_image_meta_replace_original( $saved, $file, $image_meta, $attachment_id );


### PR DESCRIPTION
- using the post editor in WordPress admin