### PR TITLE
fix: is_ssl should consider a http forward request

### DIFF
--- a/wp-includes/load.php
+++ b/wp-includes/load.php
@@ -1260,19 +1260,22 @@ function wp_installing( $is_installing = null ) {
  * @return bool True if SSL, otherwise false.
  */
 function is_ssl() {
-	if ( isset( $_SERVER['HTTPS'] ) ) {
-		if ( 'on' == strtolower( $_SERVER['HTTPS'] ) ) {
-			return true;
-		}
+        if ( isset( $_SERVER['HTTPS'] ) ) {
+                if ( 'on' == strtolower( $_SERVER['HTTPS'] ) ) {
+                        return true;
+                }    
 
-		if ( '1' == $_SERVER['HTTPS'] ) {
-			return true;
-		}
-	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
-		return true;
-	}
-	return false;
-}
+                if ( '1' == $_SERVER['HTTPS'] ) {
+                        return true;
+                }    
+        } elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' == $_SERVER['SERVER_PORT'] ) ) {
+                return true;
+        } elseif ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && 'https' == $_SERVER['HTTP_X_FORWARDED_PROTO']) {
+                return true;
+        } elseif ( isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) && ( '443' == $_SERVER['HTTP_X_FORWARDED_PORT'] ) ) {
+                return true;
+        }    
+        return false;
 
 /**
  * Converts a shorthand byte value to an integer byte value.


### PR DESCRIPTION
I really didn't understand why this function exists and why doesn't  use either siteurl or home option instead of try to detect http schema, but the point is when We try to use wordpress servers behind either a load balancer or a reverse proxy that receives requests from https and forward those to http, that function doesn't understand it and return false to ssl connection breaking all assets urls.