### PR TITLE
Added empty check in localize function

### DIFF
--- a/wp-includes/class.wp-scripts.php
+++ b/wp-includes/class.wp-scripts.php
@@ -479,7 +479,7 @@ class WP_Scripts extends WP_Dependencies {
 		}
 
 		foreach ( (array) $l10n as $key => $value ) {
-			if ( ! is_scalar( $value ) ) {
+			if ( ! is_scalar( $value ) || empty( $value ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
To prevent this warning: "Cannot assign an empty string to a string offset"