### PR TITLE
Misalignment of input elements

### DIFF
--- a/wp-admin/css/forms.css
+++ b/wp-admin/css/forms.css
@@ -76,6 +76,7 @@ input[type="week"] {
 	line-height: 2; /* 28px */
 	/* Only necessary for IE11 */
 	min-height: 30px;
+	vertical-align: middle;
 }
 
 ::-webkit-datetime-edit {


### PR DESCRIPTION
When placed side by side with select boxes, input elements are vertically misaligned in the admin area. Setting vertical-align to middle – similarly to how select boxes are defined later in this stylesheet – seems to fix the problem.

Please look at the attached screenshots to see a before/after comparison.
![input-text-no-vertical-align](https://user-images.githubusercontent.com/7178054/78504024-40054480-771f-11ea-8a44-f7a47efce5d6.png)
![input-text-vertical-align](https://user-images.githubusercontent.com/7178054/78504027-45fb2580-771f-11ea-83df-bcbf9a854e50.png)
