### PR TITLE
WP_Filesystem: SSH2 handler: load default values from constants

### DIFF
--- a/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -70,6 +70,26 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 			return;
 		}
 
+		// Load default options from constants when none provided to constructor:
+		if ($opt === '') {
+			$opt = [];
+			if ( defined( 'FTP_HOST') ) {
+				$opt['hostname'] = FTP_HOST;
+				// Split host:port into two options
+				if ( strpos( $opt['hostname'], ':' ) ) {
+					list( $opt['hostname'], $opt['port'] ) = explode( ':', $opt['hostname'], 2 );
+					if ( ! is_numeric( $opt['port'] ) ) {
+						unset( $opt['port'] );
+					}
+				}
+			}
+
+			if ( defined( 'FTP_USER') )   $opt['username']    = FTP_USER;
+			if ( defined( 'FTP_PASS') )   $opt['password']    = FTP_PASS;
+			if ( defined( 'FTP_PUBKEY') ) $opt['public_key']  = FTP_PUBKEY;
+			if ( defined( 'FTP_PRIKEY') ) $opt['private_key'] = FTP_PRIKEY;
+		}
+
 		// Set defaults:
 		if ( empty( $opt['port'] ) ) {
 			$this->options['port'] = 22;


### PR DESCRIPTION
Ticket: https://core.trac.wordpress.org/ticket/50287

Some of plugins expect FS_METHOD to be direct to control their files
They do not ask for credentials and do not expect WP_Filesystem() can
require ones.

This commit makes WP_Filesystem() with FS_METHOD='ssh2' to use FTP_*
constants as default settings when none are provided to constructor.