### PR TITLE
Update media-template.php

### DIFF
--- a/wp-includes/media-template.php
+++ b/wp-includes/media-template.php
@@ -357,10 +357,10 @@ function wp_print_media_templates() {
 			<div class="thumbnail thumbnail-{{ data.type }}">
 				<# if ( data.uploading ) { #>
 					<div class="media-progress-bar"><div></div></div>
-				<# } else if ( data.sizes && data.sizes.large ) { #>
-					<img class="details-image" src="{{ data.sizes.large.url }}" draggable="false" alt="" />
 				<# } else if ( data.sizes && data.sizes.full ) { #>
 					<img class="details-image" src="{{ data.sizes.full.url }}" draggable="false" alt="" />
+				<# } else if ( data.sizes && data.sizes.large ) { #>
+					<img class="details-image" src="{{ data.sizes.large.url }}" draggable="false" alt="" />
 				<# } else if ( -1 === jQuery.inArray( data.type, [ 'audio', 'video' ] ) ) { #>
 					<img class="details-image icon" src="{{ data.icon }}" draggable="false" alt="" />
 				<# } #>


### PR DESCRIPTION
On the line, 361 order of execution should be like this. 

1) First, check if data.sizes.full.url is available, if yes output the image source URL. (this is the URL of user's cropped image)
2) If the full URL is not available then, a large image source should be printed out. (this is the URL of original image size)

The reason is when you crop the image in the media, it still shows a large image (data.sizes.large.url) which is a full version of the image not the cropped one. So printing data.sizes .full.url first makes more sense because when user crops the image, then cropped image should be displayed in the media instead of large(original) image.