### PR TITLE
Fixed PHP warning appearing in 404 page and 'post_type' field is Arra…

### DIFF
--- a/wp-includes/canonical.php
+++ b/wp-includes/canonical.php
@@ -896,9 +896,13 @@ function redirect_guess_404_permalink() {
 		}
 
 		// If any of post_type, year, monthnum, or day are set, use them to refine the query.
-		if ( get_query_var( 'post_type' ) ) {
-			$where .= $wpdb->prepare( ' AND post_type = %s', get_query_var( 'post_type' ) );
-		} else {
+if ( $post_type = get_query_var( 'post_type' ) ) {
+	if ( is_array( $post_type ) ) {
+		$where .= " AND post_type IN ('" . implode( "', '", esc_sql( $post_type ) ) . "')";
+	} else {
+		$where .= $wpdb->prepare( ' AND post_type = %s', $post_type );
+	}
+} else {
 			$where .= " AND post_type IN ('" . implode( "', '", get_post_types( array( 'public' => true ) ) ) . "')";
 		}
 


### PR DESCRIPTION
Fixed PHP warning appearing in 404 page and 'post_type' field is Array (not string), more exactly function: `redirect_guess_404_permalink` line 700 in **wp-includes/canonical.php**

To replicate this issue simply add this code inside plugin/theme:

``` php
function _debug_php_warning_on_404( $query ) {
	$query->set( 'post_type', [ 'post', 'portfolio', 'page' ] );
} 
add_action( 'pre_get_posts', '_debug_php_warning_on_404' );
```

Then try a missing page slug _domain.test/missing-content_ it will show a warning:


> wpdb::prepare was called incorrectly. The query only expected one placeholder, but an array of multiple placeholders was sent. Please see Debugging in WordPress for more information. (This message was added in version 4.9.0.)

The fix is to replace line 700 and check for array "post_type" query var:

``` php
if ( $post_type = get_query_var( 'post_type' ) ) {
	if ( is_array( $post_type ) ) {
		$where .= " AND post_type IN ('" . implode( "', '", esc_sql( $post_type ) ) . "')";
	} else {
		$where .= $wpdb->prepare( ' AND post_type = %s', $post_type );
	}
}
```