### PR TITLE
Allow users to load WP Core, but skip load life-cycle

### DIFF
--- a/wp-includes/default-constants.php
+++ b/wp-includes/default-constants.php
@@ -118,6 +118,10 @@ function wp_initial_constants() {
 	if ( ! defined( 'SHORTINIT' ) ) {
 		define( 'SHORTINIT', false );
 	}
+	
+	if ( ! defined( 'MEDIUMINIT' ) ) {
+		define( 'MEDIUMINIT', false );
+	}
 
 	// Constants for features added to WP that should short-circuit their plugin implementations.
 	define( 'WP_FEATURE_BETTER_PASSWORDS', true );

--- a/wp-settings.php
+++ b/wp-settings.php
@@ -288,6 +288,12 @@ require ABSPATH . WPINC . '/blocks.php';
 require ABSPATH . WPINC . '/blocks/index.php';
 require ABSPATH . WPINC . '/block-patterns.php';
 
+//Allow users to load WP core without entering the action lifecycle. 
+if(MEDIUMINIT) {
+	return false;
+}
+
+
 $GLOBALS['wp_embed'] = new WP_Embed();
 
 // Load multisite-specific files.


### PR DESCRIPTION
Allow users a MEDIUMINIT load in order to load the full WP core without entering the WP loading life-cycle (plugins_loaded, init, setup_theme, etc.). This can be very helpful for ajax request that do not require plugin/theme interactions.