### PR TITLE
Change array_merge to array_merge_recursive when $override == false

### DIFF
--- a/wp-includes/rest-api/class-wp-rest-server.php
+++ b/wp-includes/rest-api/class-wp-rest-server.php
@@ -759,7 +759,7 @@ class WP_REST_Server {
 		if ( $override || empty( $this->endpoints[ $route ] ) ) {
 			$this->endpoints[ $route ] = $route_args;
 		} else {
-			$this->endpoints[ $route ] = array_merge( $this->endpoints[ $route ], $route_args );
+			$this->endpoints[ $route ] = array_merge_recursive( $this->endpoints[ $route ], $route_args );
 		}
 	}
 


### PR DESCRIPTION
Many custom plugins return nesteded arrays. If one register same endpoint with `$override == false` we are not able to add rows to nested array using same key. We can do this if we use `array_merge_recursive instead` of `array_merge`. It also should not break anything in terms of merging flat arrays.