### PR TITLE
Prevent exception when no author.

### DIFF
--- a/wp-admin/includes/media.php
+++ b/wp-admin/includes/media.php
@@ -3292,7 +3292,7 @@ function attachment_submitbox_metadata() {
 
 	$uploaded_by_name = __( '(no author)' );
 	$uploaded_by_link = '';
-	if ( $author->exists() ) {
+	if ( $author && $author->exists() ) {
 		$uploaded_by_name = $author->display_name ? $author->display_name : $author->nickname;
 		$uploaded_by_link = get_edit_user_link( $author->ID );
 	}


### PR DESCRIPTION
Additional check for when `$author` is `false` to prevent an exception from being thrown.

One example is when images are added to the media library via an import script. If the author is not defined, then an exception will be thrown when attempting to edit the media post, as you cannot call the method `exists` on a non-object.

The easiest way to get around this issue is to simply check to ensure that `$author` is not empty.