### PR TITLE
HTTP API: Add `wp_remote_put()` method

### DIFF
--- a/wp-includes/class-http.php
+++ b/wp-includes/class-http.php
@@ -607,6 +607,24 @@ class WP_Http {
 		$parsed_args = wp_parse_args( $args, $defaults );
 		return $this->request( $url, $parsed_args );
 	}
+	
+	/**
+	 * Uses the PUT HTTP method.
+	 *
+	 * Used for sending data that is expected to be in the body.
+	 *
+	 * @since 5.7
+	 *
+	 * @param string       $url  The request URL.
+	 * @param string|array $args Optional. Override the defaults.
+	 * @return array|WP_Error Array containing 'headers', 'body', 'response', 'cookies', 'filename'.
+	 *                        A WP_Error instance upon error.
+	 */
+	public function put( $url, $args = array() ) {
+		$defaults    = array( 'method' => 'PUT' );
+		$parsed_args = wp_parse_args( $args, $defaults );
+		return $this->request( $url, $parsed_args );
+	}
 
 	/**
 	 * Uses the GET HTTP method.

--- a/wp-includes/http.php
+++ b/wp-includes/http.php
@@ -180,6 +180,23 @@ function wp_remote_post( $url, $args = array() ) {
 }
 
 /**
+ * Performs an HTTP request using the PUT method and returns its response.
+ *
+ * @since 5.7
+ *
+ * @see wp_remote_request() For more information on the response array format.
+ * @see WP_Http::request() For default arguments information.
+ *
+ * @param string $url  URL to retrieve.
+ * @param array  $args Optional. Request arguments. Default empty array.
+ * @return array|WP_Error The response or WP_Error on failure.
+ */
+function wp_remote_put( $url, $args = array() ) {
+	$http = _wp_http_get_object();
+	return $http->put( $url, $args );
+}
+
+/**
  * Performs an HTTP request using the HEAD method and returns its response.
  *
  * @since 2.7.0


### PR DESCRIPTION
This method performs an HTTP request using the PUT method and returns its response.