### PR TITLE
Fix PHP Warning on PHP7.2 in class-wp-http-curl.php

### DIFF
--- a/wp-includes/class-wp-http-curl.php
+++ b/wp-includes/class-wp-http-curl.php
@@ -77,6 +77,7 @@ class WP_Http_Curl {
 			'headers'     => array(),
 			'body'        => null,
 			'cookies'     => array(),
+			'decompress'  => false,
 		);
 
 		$parsed_args = wp_parse_args( $args, $defaults );


### PR DESCRIPTION
Added the default settings parameter 'decompress' with the default value 'false'.
When not pre-defined it will result in a error, because it is used on line 316: (without isset() check)
 
if ( true === $parsed_args['decompress'] && ...