### PR TITLE
Fix PHP Warning on PHP8.0 for non-posts/pages

### DIFF
--- a/wp-includes/class-wp-query.php
+++ b/wp-includes/class-wp-query.php
@@ -4038,6 +4038,10 @@ class WP_Query {
 		}
 
 		$page_obj = $this->get_queried_object();
+		
+		if ( ! isset( $page_obj->ID ) && ! isset( $page_obj->post_title ) && ! isset( $page_obj->post_name ) ) {
+			return false;
+		}
 
 		$page = array_map( 'strval', (array) $page );
 
@@ -4192,6 +4196,10 @@ class WP_Query {
 		}
 
 		$post_obj = $this->get_queried_object();
+		
+		if ( ! isset( $post_obj->post_type ) ) {
+			return false;
+		}
 
 		return in_array( $post_obj->post_type, (array) $post_types, true );
 	}


### PR DESCRIPTION
In PHP 8.0, when accessing the non-posts/pages like /data/feed and /data/rss, it shows an PHP Warning error saying "Attempt to read property "post_title" on null".

This fix added an isset check for the variable and immediately return false value.