### PR TITLE
Fix for ticket 42957, preventing some users from creating accounts

### DIFF
--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -7560,6 +7560,19 @@ function wp_get_direct_php_update_url() {
 }
 
 /**
+ * Encode this url, like rawurlencode. If it ends in a period, replace that with %2E.
+ *
+ * This is done because gmail doesn't interpret it correctly otherwise.
+ * See https://core.trac.wordpress.org/ticket/42957 for background.
+ *
+ * @param string  $url Any url.
+ * @return string Encoded url.
+ */
+function wp_half_baked_url_encode( $url ) {
+	 return preg_replace( "/\.$/", "%2E", rawurlencode( $url ) );
+}
+
+/**
  * Display a button directly linking to a PHP update process.
  *
  * This provides hosts with a way for users to be sent directly to their PHP update process.

--- a/wp-includes/pluggable.php
+++ b/wp-includes/pluggable.php
@@ -2082,7 +2082,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 		/* translators: %s: User login. */
 		$message  = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 		$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
-		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . "\r\n\r\n";
+		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . wp_half_baked_url_encode( $user->user_login ), 'login' ) . "\r\n\r\n";
 
 		$message .= wp_login_url() . "\r\n";
 

--- a/wp-includes/user.php
+++ b/wp-includes/user.php
@@ -2771,7 +2771,7 @@ function retrieve_password( $user_login = null ) {
 	$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, ignore this email and nothing will happen.' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . "\r\n\r\n";
+	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . wp_half_baked_url_encode( $user_login ), 'login' ) . "\r\n\r\n";
 
 	if ( ! is_user_logged_in() ) {
 		$requester_ip = $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
On my website we get about one email a month from a person who can't create an account. This turns out to be caused by https://core.trac.wordpress.org/ticket/42957

- you're using gmail
- you try to create an account name ending in a period, e.g. Dave P.
- the email is sent containing https://blah...&login=Dave%20P.
- gmail generally assumes links ending in periods have the periods added by humans and thus ignores them
- so clicking on it, you arrive at https://blah...&login=Dave%20P and the user's told the link is invalid

Fixes this by encoding the trailing period as an entity.

This is my first submitted pull request to WP, thanks in advance for telling me if any more steps are needed.