### PR TITLE
Remove mutliple "-" on cleanForSlug

### DIFF
--- a/wp-includes/js/dist/editor.js
+++ b/wp-includes/js/dist/editor.js
@@ -2725,7 +2725,7 @@ function cleanForSlug(string) {
     return '';
   }
 
-  return Object(external_lodash_["trim"])(Object(external_lodash_["deburr"])(string).replace(/[\s\./]+/g, '-').replace(/[^\w-]+/g, '').toLowerCase(), '-');
+  return Object(external_lodash_["trim"])(Object(external_lodash_["deburr"])(string).replace(/[\s\./]+/g, '-').replace(/[^\w-]+/g, '').replace(/-+/g, '-').toLowerCase(), '-');
 }
 
 // CONCATENATED MODULE: ./node_modules/@wordpress/editor/build-module/store/selectors.js

--- a/wp-includes/js/dist/url.js
+++ b/wp-includes/js/dist/url.js
@@ -1019,7 +1019,7 @@ function cleanForSlug(string) {
     return '';
   }
 
-  return Object(external_lodash_["trim"])(Object(external_lodash_["deburr"])(string).replace(/[\s\./]+/g, '-').replace(/[^\w-]+/g, '').toLowerCase(), '-');
+  return Object(external_lodash_["trim"])(Object(external_lodash_["deburr"])(string).replace(/[\s\./]+/g, '-').replace(/[^\w-]+/g, '').replace(/-+/g, '-').toLowerCase(), '-');
 }
 
 // CONCATENATED MODULE: ./node_modules/@wordpress/url/build-module/index.js


### PR DESCRIPTION
This function calculates a slug from a string in JS. But the result differ of the slug really generated by Wordpress and stored in database.