### PR TITLE
Update wp-db.php

### DIFF
--- a/wp-includes/wp-db.php
+++ b/wp-includes/wp-db.php
@@ -1159,7 +1159,7 @@ class wpdb {
 	 * @return string Escaped string.
 	 */
 	function _real_escape( $string ) {
-		if ( ! is_scalar( $string ) && ! is_null( $string ) ) {
+		if ( ! ( is_object( $string ) && method_exists( $string , '__toString' ) ) && ! is_scalar( $string ) && ! is_null( $string ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
Restore old behavior and allow $string argument for `wpdb::_real_escape()` to contain objects with a `__toString` method defined, because these objects are stringable.

This commit is a response to the recent commit that broke the old behavior:
https://github.com/WordPress/WordPress/commit/9734ed5673f6e7b3d8146c6bc7a0e8b82abe5d4a