### PR TITLE
Added AJAX_DEBUG Constant for better ajax debugging 

### DIFF
--- a/wp-admin/admin-header.php
+++ b/wp-admin/admin-header.php
@@ -89,6 +89,9 @@ var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?
 	thousandsSeparator = '<?php echo esc_js( $wp_locale->number_format['thousands_sep'] ); ?>',
 	decimalPoint = '<?php echo esc_js( $wp_locale->number_format['decimal_point'] ); ?>',
 	isRtl = <?php echo (int) is_rtl(); ?>;
+<?php if ( defined( 'AJAX_DEBUG' ) && AJAX_DEBUG ): ?>
+var ajaxDebug = true;
+<?php endif; ?>
 </script>
 <?php
 

--- a/wp-admin/includes/template.php
+++ b/wp-admin/includes/template.php
@@ -2034,6 +2034,9 @@ var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?
 	thousandsSeparator = '<?php echo esc_js( $wp_locale->number_format['thousands_sep'] ); ?>',
 	decimalPoint = '<?php echo esc_js( $wp_locale->number_format['decimal_point'] ); ?>',
 	isRtl = <?php echo (int) is_rtl(); ?>;
+<?php if ( defined( 'AJAX_DEBUG' ) && AJAX_DEBUG ): ?>
+var ajaxDebug = true;
+<?php endif; ?>
 </script>
 	<?php
 	/** This action is documented in wp-admin/admin-header.php */

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -81,7 +81,8 @@ define( 'WP_DEBUG', false );
 
 /**
  * AJAX_DEBUG = true will added action as url parameter debug=AJAX_ACTION
- * This will help developers to filter out the ajax requests from Browser Developer Tools Network tab.
+ * This will help developers to filter out the ajax requests from Browser Developer Tools Network tab,
+ * without having to click every ajax request to check what it is for.
  */
 define( 'AJAX_DEBUG', false );
 

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -79,6 +79,12 @@ $table_prefix = 'wp_';
  */
 define( 'WP_DEBUG', false );
 
+/**
+ * AJAX_DEBUG = true will added action as url parameter debug=AJAX_ACTION
+ * This will help developers to filter out the ajax requests from Browser Developer Tools Network tab.
+ */
+define( 'AJAX_DEBUG', false );
+
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */

--- a/wp-includes/general-template.php
+++ b/wp-includes/general-template.php
@@ -4842,7 +4842,12 @@ function __checked_selected_helper( $helper, $current, $echo, $type ) { // phpcs
  */
 function wp_heartbeat_settings( $settings ) {
 	if ( ! is_admin() ) {
-		$settings['ajaxurl'] = admin_url( 'admin-ajax.php', 'relative' );
+		if ( defined( 'AJAX_DEBUG' ) && AJAX_DEBUG ) {
+			// Adding Ajax debug
+			$settings['ajaxurl'] = admin_url( 'admin-ajax.php?debug=heartbeat', 'relative' );
+		} else {
+			$settings['ajaxurl'] = admin_url( 'admin-ajax.php', 'relative' );
+		}
 	}
 
 	if ( is_user_logged_in() ) {

--- a/wp-includes/js/heartbeat.js
+++ b/wp-includes/js/heartbeat.js
@@ -120,6 +120,9 @@
 
 			if ( typeof window.ajaxurl === 'string' ) {
 				settings.url = window.ajaxurl;
+                if ( window.ajaxDebug === true ) {
+                    settings.url += "?debug=heartbeat"
+                }
 			}
 
 			// Pull in options passed from PHP.

--- a/wp-includes/js/wp-util.js
+++ b/wp-includes/js/wp-util.js
@@ -90,7 +90,7 @@ window.wp = window.wp || {};
 
 			options = _.defaults( options || {}, {
 				type:    'POST',
-				url:     wp.ajax.settings.url,
+				url:     wp.ajax.settings.url + ( wp.ajax.settings.debug ? "?debug=" + options.data.action : "" ),
 				context: this
 			});
 

--- a/wp-includes/script-loader.php
+++ b/wp-includes/script-loader.php
@@ -920,14 +920,20 @@ function wp_default_scripts( $scripts ) {
 	$scripts->add( 'backbone', "/wp-includes/js/backbone$dev_suffix.js", array( 'underscore', 'jquery' ), '1.4.0', 1 );
 
 	$scripts->add( 'wp-util', "/wp-includes/js/wp-util$suffix.js", array( 'underscore', 'jquery' ), false, 1 );
+
+	$_wpUtilSettings = array(
+		'ajax' => array(
+			'url' => admin_url( 'admin-ajax.php', 'relative' ),
+		),
+	);
+	if ( defined( 'AJAX_DEBUG' ) && AJAX_DEBUG ) {
+		$_wpUtilSettings['ajax']['debug'] = true;
+	}
+
 	did_action( 'init' ) && $scripts->localize(
 		'wp-util',
 		'_wpUtilSettings',
-		array(
-			'ajax' => array(
-				'url' => admin_url( 'admin-ajax.php', 'relative' ),
-			),
-		)
+		$_wpUtilSettings
 	);
 
 	$scripts->add( 'wp-backbone', "/wp-includes/js/wp-backbone$suffix.js", array( 'backbone', 'wp-util' ), false, 1 );


### PR DESCRIPTION
AJAX_DEBUG = true will added action as url parameter debug=AJAX_ACTION. This will help developers to filter out the ajax requests from Browser Developer Tools Network tab, without having to click every ajax request to check what it is for.

Its been bothering me a lot and i think it bothered lot of other developers too. For every ajax call, I have to click on each request ( in case there are multiple network request listed ) and have to check the request data or the request parameters to figure out which one is my request.

This will help developers to just use search filter from network tab for filtering out their own request or any other request they want to check.

![network tool](https://user-images.githubusercontent.com/47305069/115192507-8a7a1900-a108-11eb-9b5c-bdb5d450b906.jpg)

Wordpress Trac Ticket link: https://core.trac.wordpress.org/ticket/53057#ticket
Ticket ID: 53057