### PR TITLE
Update class-walker-comment.php

### DIFF
--- a/wp-includes/class-walker-comment.php
+++ b/wp-includes/class-walker-comment.php
@@ -200,7 +200,7 @@ class Walker_Comment extends Walker {
 		}
 
 		if ( 'comment' === $comment->comment_type ) {
-			remove_filter( 'comment_text', array( $this, 'filter_comment_text' ), 40, 2 );
+			remove_filter( 'comment_text', array( $this, 'filter_comment_text' ), 40 );
 		}
 	}
 


### PR DESCRIPTION
Nit: `remove_filter` takes 3 parameters, with 4 given. Might cause a PHP Warning message.

https://core.trac.wordpress.org/ticket/53113