### PR TITLE
Fix a typo. Line 2713 $s10 should be $s8

### DIFF
--- a/wp-includes/sodium_compat/src/Core32/Curve25519.php
+++ b/wp-includes/sodium_compat/src/Core32/Curve25519.php
@@ -2710,7 +2710,7 @@ abstract class ParagonIE_Sodium_Core32_Curve25519 extends ParagonIE_Sodium_Core3
         $carry7 = $s7->shiftRight(21);
         $s8 = $s8->addInt64($carry7);
         $s7 = $s7->subInt64($carry7->shiftLeft(21));
-        $carry8 = $s10->shiftRight(21);
+        $carry8 = $s8->shiftRight(21);
         $s9 = $s9->addInt64($carry8);
         $s8 = $s8->subInt64($carry8->shiftLeft(21));
         $carry9 = $s9->shiftRight(21);


### PR DESCRIPTION
Based on pattern analysis, Curve 25519.php has an irregularity. 

The Line number 2713:

$carry8 = $s10->shiftRight(21);

should be:

$carry8 = $s8->shiftRight(21);

Please refer to the other lines. For example, around Line number 3070 has the same logic.