### PR TITLE
Reduce padding to allow Firefox to use number input buttons. 

### DIFF
--- a/wp-content/themes/twentytwenty/style-rtl.css
+++ b/wp-content/themes/twentytwenty/style-rtl.css
@@ -790,6 +790,10 @@ textarea {
 	width: 100%;
 }
 
+input[type="number"] {
+	padding-left: .5rem;
+}
+
 select {
 	font-size: 1em;
 }

--- a/wp-content/themes/twentytwenty/style.css
+++ b/wp-content/themes/twentytwenty/style.css
@@ -796,6 +796,10 @@ textarea {
 	width: 100%;
 }
 
+input[type="number"] {
+	padding-right: .5rem;
+}
+
 select {
 	font-size: 1em;
 }


### PR DESCRIPTION
Closes Trac #53115.

source: https://core.trac.wordpress.org/ticket/53115

Firefox number input buttons are not clickable due to too much left/right padding.