### PR TITLE
fixing problem with hummingbird plugin

### DIFF
--- a/wp-includes/theme.php
+++ b/wp-includes/theme.php
@@ -3595,7 +3595,7 @@ function wp_customize_support_script() {
 	<?php	endif; ?>
 
 			b[c] = b[c].replace( rcs, ' ' );
-			// The customizer requires postMessage and CORS (if the site is cross domain).
+			/* The customizer requires postMessage and CORS (if the site is cross domain). */
 			b[c] += ( window.postMessage && request ? ' ' : ' no-' ) + cs;
 		}());
 	</script>


### PR DESCRIPTION
in javascript it should be avoided to use single line comments, so that there are no problems with plugins like Hummingbird. Which pack HTML and javascript. Otherwise you will get an "end of input" error.