### PR TITLE
Add filters for $this->posts in WP_Query when fields is ids or id=>parent

### DIFF
--- a/wp-includes/class-wp-query.php
+++ b/wp-includes/class-wp-query.php
@@ -3000,7 +3000,20 @@ class WP_Query {
 			}
 
 			/** @var int[] */
-			$this->posts      = array_map( 'intval', $this->posts );
+			$this->posts = array_map( 'intval', $this->posts );
+
+			if ( ! $q['suppress_filters'] ) {
+				/**
+				 * Filters the post IDs array when returning ids.
+				 *
+				 * @since TBD
+				 *
+				 * @param int[]    $posts The list of post IDs.
+				 * @param WP_Query $query The WP_Query instance.
+				 */
+				$this->posts = apply_filters( 'posts_results_ids', $this->posts, $this );
+			}
+
 			$this->post_count = count( $this->posts );
 			$this->set_found_posts( $q, $limits );
 
@@ -3010,6 +3023,18 @@ class WP_Query {
 		if ( 'id=>parent' === $q['fields'] ) {
 			if ( null === $this->posts ) {
 				$this->posts = $wpdb->get_results( $this->request );
+			}
+
+			if ( ! $q['suppress_filters'] ) {
+				/**
+				 * Filters the basic post objects array when returning id=>parent.
+				 *
+				 * @since TBD
+				 *
+				 * @param stdClass[] $posts The list of basic post objects containing ID and post_parent.
+				 * @param WP_Query   $query The WP_Query instance.
+				 */
+				$this->posts = apply_filters( 'posts_results_id_parent', $this->posts, $this );
 			}
 
 			$this->post_count = count( $this->posts );


### PR DESCRIPTION
The WP_Query class offers no ability to hook into queries that return posts as IDs or ID => Parent format. The changes proposed here introduce new filters that offer similar capabilities to the pre-existing `posts_results` filter which runs in other cases.