### PR TITLE
Allow for nestable superscript tags

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -2523,7 +2523,7 @@ function force_balance_tags( $text ) {
 	// Known single-entity/self-closing tags.
 	$single_tags = array( 'area', 'base', 'basefont', 'br', 'col', 'command', 'embed', 'frame', 'hr', 'img', 'input', 'isindex', 'link', 'meta', 'param', 'source', 'track', 'wbr' );
 	// Tags that can be immediately nested within themselves.
-	$nestable_tags = array( 'article', 'aside', 'blockquote', 'details', 'div', 'figure', 'object', 'q', 'section', 'span' );
+	$nestable_tags = array( 'article', 'aside', 'blockquote', 'details', 'div', 'figure', 'object', 'q', 'section', 'span', 'sup' );
 
 	// WP bug fix for comments - in case you REALLY meant to type '< !--'.
 	$text = str_replace( '< !--', '<    !--', $text );


### PR DESCRIPTION
Allow for nestable superscript tags required for proper mathematical notation, s.

https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements