### PR TITLE
Trac #48285 wp-config-sample.php change to utf8mb4

### DIFF
--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -32,7 +32,7 @@ define( 'DB_PASSWORD', 'password_here' );
 define( 'DB_HOST', 'localhost' );
 
 /** Database charset to use in creating database tables. */
-define( 'DB_CHARSET', 'utf8' );
+define( 'DB_CHARSET', 'utf8mb4' );
 
 /** The database collate type. Don't change this if in doubt. */
 define( 'DB_COLLATE', '' );


### PR DESCRIPTION
Fixes discussion in https://core.trac.wordpress.org/ticket/48285

Wordpress requirements listed at https://wordpress.org/about/requirements/ indicate that MySQL version 5.7 is required.

The `utf8mb4` character set was released in MySQL version 5.5.3 in 2010. (See page 159 of https://downloads.mysql.com/docs/mysql-5.5-relnotes-en.pdf.  The MySQL Release Notes on mysql.com no longer to back to v5.5).

