### PR TITLE
Recreate plugins_api response for tab

### DIFF
--- a/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -239,6 +239,18 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		}
 
 		$api = plugins_api( 'query_plugins', $args );
+		
+		/**
+		 * Filter the API response to recreate the api response
+		 * 
+		 * The dynamic portion of the hook name, `$tab`, refers to the plugin install tabs.
+		 * 
+		 * @since 6.0-alpha-52644
+		 * 
+		 * @param mixed $api response plugin_api
+		 */
+		
+		$api = apply_filters( "install_plugins_recreate_response_api_{$tab}", $api );
 
 		if ( is_wp_error( $api ) ) {
 			$this->error = $api;


### PR DESCRIPTION
Recreate plugins_api response in mixed variable $api

## Functionality derived from this change
### Crate custom list plugin install
```
/**
 * Adding tab view plugin_install
 */
add_filter( 'views_plugin-install', function ($views){
	get_admin_url();
	$url = get_admin_url();
	$views['plugin-install-poschapin'] = "<a href='{$url}plugin-install.php?tab=poschapin' class=\"current\" aria-current=\"page\">Poschapin</a>";
	return $views;
},10,1);

/**
 * Adding tab plugin_install
 */
add_filter( 'install_plugins_tabs', function ($tabs){
	$tabs['poschapin'] = 'PosChapin Dependencias';
	return $tabs;
},10,1);

/**
 * Modify arguments by tab
 */
add_filter( 'install_plugins_table_api_args_poschapin', function ($args){
	$args = array(
		'page'     => 1,
		'per_page' => 36,
		// Send the locale to the API so it can provide context-sensitive results.
		'locale'   => get_user_locale(),
	);
	return $args;
},10,1);

/**
 * Recreate plugins_api response 
 */
add_filter( 'install_plugins_recreate_response_api_poschapin', function ($api){
	$api = get_transient('plugins_install_api');
	/**
	 * check transient and force-check if transient is valid and new data needs to be loaded
	 */
	if($api == false || isset($_GET['force-check'])){
		/**
		 * List plugins custom
		 * @var array
		 */
		$plugins_list = array(
			'duplicator',
			'edit-author-slug',
			'fancy-admin-ui',
			'google-apps-login',
			'loco-translate',
			'login-lockdown',
			'peters-login-redirect',
			'really-simple-ssl',
			'simple-history',
			'user-login-history',
			'wa-sticky-button',
			'wpfront-user-role-editor',
		);

		$api = new stdClass();
	  	$api->info = array (
		      'page' => 1,
		      'pages' => 1,
		      'results' => count($plugins_list),
		);
	  	$api->plugins = array();
	  	
		$custom_args = array();
		
		$custom_args['fields'] = array(
			'short_description' => true,        // string
			'icons' => true,                    // array( [1x] url, [2x] url )
		);
		
		
		
		foreach ($plugins_list as $slugs => $slug) {
			$custom_args['slug'] = $slug;
			$custom_data = (array)plugins_api( 'plugin_information', $custom_args );
			array_push($api->plugins, $custom_data);
		}
		/**
		 * set transient 12 HOURS
		 */
		set_transient( 'plugins_install_api', $api, 12 * HOUR_IN_SECONDS );
	}
	return $api;
},10,1);

/**
 * init display
 */
add_action('install_plugins_poschapin',function($paged){
	global $wp_list_table;

	$wp_list_table->display();
},10,1);
```
How it looks, when adding a new plugin

The `poschapin` tab is displayed

![image](https://user-images.githubusercontent.com/37667605/151275086-0027172d-6948-4602-b924-1071831dfa63.png)


