### PR TITLE
Fix null pointer exception: `WP_Query::is_singular()` returns false if `WP_Query::get_queried_object()` is `null`

### DIFF
--- a/wp-includes/class-wp-query.php
+++ b/wp-includes/class-wp-query.php
@@ -4334,6 +4334,10 @@ class WP_Query {
 		}
 
 		$post_obj = $this->get_queried_object();
+		
+		if ($post_obj === null) {
+			return false;
+		}
 
 		return in_array( $post_obj->post_type, (array) $post_types, true );
 	}


### PR DESCRIPTION
As `WP_Query::get_queried_object()` may return `null` and, in certain scenarios, it does, calls to `WP_Query::is_singular()` may emit an `E_NOTICE` level error due to accessing the `post_type` property of a non-object in the `in_array` check that follows.

A null-check is added that shortcuts and returns false in this scenario.