### PR TITLE
Updated declaration syntax for php version 8

### DIFF
--- a/wp-includes/template.php
+++ b/wp-includes/template.php
@@ -700,13 +700,13 @@ function locate_template( $template_names, $load = false, $require_once = true, 
 		if ( ! $template_name ) {
 			continue;
 		}
-		if ( file_exists( STYLESHEETPATH . '/' . $template_name ) ) {
+		if ( file_exists( 'STYLESHEETPATH' . '/' . $template_name ) ) {
 			$located = STYLESHEETPATH . '/' . $template_name;
 			break;
-		} elseif ( file_exists( TEMPLATEPATH . '/' . $template_name ) ) {
+		} elseif ( file_exists( 'TEMPLATEPATH' . '/' . $template_name ) ) {
 			$located = TEMPLATEPATH . '/' . $template_name;
 			break;
-		} elseif ( file_exists( ABSPATH . WPINC . '/theme-compat/' . $template_name ) ) {
+		} elseif ( file_exists( 'ABSPATH' . WPINC . '/theme-compat/' . $template_name ) ) {
 			$located = ABSPATH . WPINC . '/theme-compat/' . $template_name;
 			break;
 		}


### PR DESCRIPTION
added inverted commas to 'STYLESHEETPATH', 'TEMPLATEPATH', 'ABSPATH' in accordance with php 8 syntax