### PR TITLE
Fix: rtrim null argument perameter issue

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -2769,7 +2769,7 @@ function trailingslashit( $string ) {
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $string ) {
-	return rtrim( $string, '/\\' );
+	return rtrim( (string)$string, '/\\' );
 }
 
 /**


### PR DESCRIPTION
I'm currently using WordPress Version 6.0 and my PHP version is 8.1 and I'm facing an Deprecated issue in PHP 8.1. When I'm using PHP 8.0 or less then I didn't face the issue. I think this error is in PHP 8.1.
For better understanding, check the screenshot below:
https://prnt.sc/WHSC4O5gmxJB

And this issue is fixed