### PR TITLE
use constant-time hash compare

### DIFF
--- a/wp-includes/class-phpass.php
+++ b/wp-includes/class-phpass.php
@@ -241,10 +241,14 @@ class PasswordHash {
 		if ($hash[0] === '*')
 			$hash = crypt($password, $stored_hash);
 
-		# This is not constant-time.  In order to keep the code simple,
-		# for timing safety we currently rely on the salts being
-		# unpredictable, which they are at least in the non-fallback
-		# cases (that is, when we use /dev/urandom and bcrypt).
-		return $hash === $stored_hash;
+		if(PHP_VERSION_ID >= 50600){
+			return hash_equals($stored_hash, $hash);
+		} else {
+			# This is not constant-time.  In order to keep the code simple,
+			# for timing safety we currently rely on the salts being
+			# unpredictable, which they are at least in the non-fallback
+			# cases (that is, when we use /dev/urandom and bcrypt).
+			return $hash === $stored_hash;
+		}
 	}
 }


### PR DESCRIPTION
.. on PHP>=5.6.0
notably it would be possible to implement constant time on <5.6.0, but it's probably not worth the effort. the PHP_VERSION_ID constant was introduced in PHP 5.2.7

Unsure if WordPress still support 5.5? if the answer is no, the entire PHP_VERSION_ID check can be removed.

See https://core.trac.wordpress.org/ticket/56335
