### PR TITLE
Update nav-menus.css

### DIFF
--- a/wp-admin/css/nav-menus.css
+++ b/wp-admin/css/nav-menus.css
@@ -851,8 +851,10 @@ body.menu-max-depth-11 { min-width: 1280px !important; }
 
 /* Same as the Publish Meta Box #delete-action */
 .nav-menus-php .delete-action {
-	float: left;
-	line-height: 2.1;
+	float: right;
+    	line-height: 2.1;
+    	margin: 0 15px;
+	
 }
 
 .nav-menus-php .major-publishing-actions .form-invalid {


### PR DESCRIPTION
Several users have reported to me a UX issue with the location of this action. When deleting a submenu item, it could be mistaken for the action that clears the item and clears the entire menu by mistake.