### PR TITLE
added null coelsing operator for rtrim function to avoid deprecation …

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -2780,7 +2780,7 @@ function trailingslashit( $string ) {
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $string ) {
-	return rtrim( $string, '/\\' );
+	return rtrim( $string ?? '', '/\\' );
 }
 
 /**


### PR DESCRIPTION
There was a warning showing `Deprecated: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/wordpress/wordpress/wp-includes/formatting.php on line 2872`
The rtrim function 1st parameter value as null is deprecated in php 8.1. It can be fixed by adding ` null coalescing ` operator.