### PR TITLE
Update wp-load.php

### DIFF
--- a/wp-load.php
+++ b/wp-load.php
@@ -18,7 +18,7 @@
 
 /** Define ABSPATH as this file's directory */
 if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', __DIR__ . '/' );
+	define( 'ABSPATH', __DIR__ . DIRECTORY_SEPARATOR  );
 }
 
 /*


### PR DESCRIPTION
DIRECTORY_SEPARATOR  is portable than  '/'