### PR TITLE
strpos first parameter null problem

### DIFF
--- a/wp-includes/shortcodes.php
+++ b/wp-includes/shortcodes.php
@@ -204,6 +204,11 @@ function apply_shortcodes( $content, $ignore_html = false ) {
  */
 function do_shortcode( $content, $ignore_html = false ) {
 	global $shortcode_tags;
+	
+	/* PHP 8.2 arise deprecated message when $content variable is null */
+	if ( $content === null ) {
+		return null;
+	}
 
 	if ( false === strpos( $content, '[' ) ) {
 		return $content;


### PR DESCRIPTION
PHP 8.2 deprecated strpos first parameter null value. So that i add a condition. which is not create any problem with other php version.  

if ( $content === null ) {
		return null;
}