### PR TITLE
9 chars instead of 12 in wp_get_password_hint()

### DIFF
--- a/wp-includes/user.php
+++ b/wp-includes/user.php
@@ -2833,7 +2833,7 @@ function _wp_get_user_contactmethods( $user = null ) {
  * @return string The password hint text.
  */
 function wp_get_password_hint() {
-	$hint = __( 'Hint: The password should be at least twelve characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! " ? $ % ^ &amp; ).' );
+	$hint = __( 'Hint: The password should be at least nine characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! " ? $ % ^ &amp; ).' );
 
 	/**
 	 * Filters the text describing the site's password complexity policy.


### PR DESCRIPTION
Wordpress uses [zxcvbn](https://github.com/dropbox/zxcvbn) to check password strengths and sets the minimum required strength to **3**. `wp_get_password_hint()` mistakenly informs the user that a mininum password length of is 12 required when a length of 9 is actually being accepted.