### PR TITLE
Update formatting.php ltrim() error

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -4389,9 +4389,13 @@ function esc_url( $url, $protocols = null, $_context = 'display' ) {
 		return $url;
 	}
 
-	$url = str_replace( ' ', '%20', ltrim( $url ) );
-	$url = preg_replace( '|[^a-z0-9-~+_.?#=!&;,/:%@$\|*\'()\[\]\\x80-\\xff]|i', '', $url );
-
+    	if(is_string($url)){
+		$url = str_replace( ' ', '%20', ltrim( $url ) );
+		$url = preg_replace( '|[^a-z0-9-~+_.?#=!&;,/:%@$\|*\'()\[\]\\x80-\\xff]|i', '', $url );
+    	}else{
+        	$url = '';
+    	}
+	
 	if ( '' === $url ) {
 		return $url;
 	}


### PR DESCRIPTION
Warning: ltrim() expects parameter 1 to be string, object given in /home/user/public_html/project/wp-includes/formatting.php on line 4378

---------

Returns empty url if it comes as an object