### PR TITLE
Update class-wp-automatic-updater.php

### DIFF
--- a/wp-admin/includes/class-wp-automatic-updater.php
+++ b/wp-admin/includes/class-wp-automatic-updater.php
@@ -149,6 +149,7 @@ class WP_Automatic_Updater {
 
 		$check_dirs = array_unique( $check_dirs );
 
+		$checkout = false;
 		// Search all directories we've found for evidence of version control.
 		foreach ( $vcs_dirs as $vcs_dir ) {
 			foreach ( $check_dirs as $check_dir ) {


### PR DESCRIPTION
PHP 8.2 produce
Warning: Undefined variable $checkout in wordpress/wp-admin/includes/class-wp-automatic-updater.php on line 176