### PR TITLE
Ensure that the page parameter is scalar in wp-query

### DIFF
--- a/wp-includes/class-wp-query.php
+++ b/wp-includes/class-wp-query.php
@@ -2020,8 +2020,8 @@ class WP_Query {
 		}
 
 		if ( isset( $q['page'] ) ) {
-			$q['page'] = trim( $q['page'], '/' );
-			$q['page'] = absint( $q['page'] );
+			$qv['page']    = is_scalar( $qv['page'] ) ? trim( $q['page'], '/'  : '';
+			$qv['page']    = is_scalar( $qv['page'] ) ? absint( $qv['page'] ) : 0;
 		}
 
 		// If true, forcibly turns off SQL_CALC_FOUND_ROWS even when limits are present.


### PR DESCRIPTION

This work completed with the closure of https://core.trac.wordpress.org/ticket/17737

It ensures that the value of `$page` in a query is scalar prior to attempting to trim or assign it to an absint avoiding a fatal error if an array is passed. 

Fixes: https://core.trac.wordpress.org/ticket/56558 (comment 2)