### PR TITLE
Update load.php

### DIFF
--- a/wp-includes/load.php
+++ b/wp-includes/load.php
@@ -85,7 +85,7 @@ function wp_fix_server_vars() {
 	}
 
 	// Fix empty PHP_SELF.
-	$PHP_SELF = $_SERVER['PHP_SELF'];
+	$PHP_SELF = $_SERVER['PHP_SELF'] ?? null;
 	if ( empty( $PHP_SELF ) ) {
 		$_SERVER['PHP_SELF'] = preg_replace( '/(\?.*)?$/', '', $_SERVER['REQUEST_URI'] );
 		$PHP_SELF            = $_SERVER['PHP_SELF'];


### PR DESCRIPTION
Fixes Undefined array key "PHP_SELF" under PHP 8.

This notice is only given when mocking the Wordpress core.