### PR TITLE
In some cases the footnotes aren't valid JSON.

### DIFF
--- a/wp-includes/blocks/footnotes.php
+++ b/wp-includes/blocks/footnotes.php
@@ -34,7 +34,7 @@ function render_block_core_footnotes( $attributes, $content, $block ) {
 
 	$footnotes = json_decode( $footnotes, true );
 
-	if ( count( $footnotes ) === 0 ) {
+	if ( ! $footnotes || ! is_countable( $footnotes ) || count( $footnotes ) === 0 ) {
 		return '';
 	}
 


### PR DESCRIPTION
Inspired by this issue: https://wordpress.org/support/topic/footnote-fatal-error/#post-16983995