### PR TITLE
[Compatibility Enhancement]Allow a string value in sortable columns

### DIFF
--- a/wp-admin/includes/class-wp-list-table.php
+++ b/wp-admin/includes/class-wp-list-table.php
@@ -1434,6 +1434,7 @@ class WP_List_Table {
 			}
 
 			if ( isset( $sortable[ $column_key ] ) ) {
+				$sortable[ $column_key ] = (array) $sortable[ $column_key ];
 				$orderby       = isset( $sortable[ $column_key ][0] ) ? $sortable[ $column_key ][0] : '';
 				$desc_first    = isset( $sortable[ $column_key ][1] ) ? $sortable[ $column_key ][1] : false;
 				$abbr          = isset( $sortable[ $column_key ][2] ) ? $sortable[ $column_key ][2] : '';


### PR DESCRIPTION
Accepts string values, similar to get_sortable_columns().
https://github.com/WordPress/WordPress/blob/127209a9feee6290b421cc4d3dd0b40e8f8ed72b/wp-admin/includes/class-wp-list-table.php#L1180

**Code to reproduce**
wp-content\plugins\hello.php
```php
<?php

/*
Plugin Name: Hello Dolly
Version: 1.7.2
*/

if (!class_exists('WP_List_Table')) {
	require_once(ABSPATH . 'wp-admin/includes/class-wp-list-table.php');
}

class My_List_Table extends WP_List_Table
{
	public function prepare_items()
	{
		$this->items = [
			[ 'name' => 'Apple', 'color' => 'red', 'price' => 100 ],
			[ 'name' => 'Banana', 'color' => 'yellow', 'price' => 60 ],
			[ 'name' => 'Melon', 'color' => 'green', 'price' => 200 ],
		];
		$this->_column_headers = array($this->get_columns(), array(), $this->get_sortable_columns());
	}

	public function get_columns()
	{
		return [
			'name' => 'Name',
			'color' => 'Color',
			'price' => 'Price'
		];
	}

	public function get_sortable_columns(): array
	{
		return array(
			'name' => 'name',
			'color' => 'color',
			'price' => 'price'
		);
	}

	public function column_default($item, $column_name)
	{
		return $item[$column_name];
	}
}

function my_add_menu_items()
{
	$myListTable = new My_List_Table();
	add_menu_page('My Plugin List Table', 'My List Table Example', 'activate_plugins', 'my_list_test', function () use ($myListTable) {
		$myListTable->prepare_items();
		$myListTable->display();
	});
}
add_action('admin_menu', 'my_add_menu_items');
```

![image](https://github.com/WordPress/WordPress/assets/121648127/c6ee1e9d-3aff-4d43-9cbb-56e817614cc3)

Fixed by this commit
![image](https://github.com/WordPress/WordPress/assets/121648127/b9fa8709-ca2b-48fb-bafb-a093286f5187)
