### PR TITLE
prevent null on preg_split function

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -3502,6 +3502,10 @@ function convert_smilies( $text ) {
 	global $wp_smiliessearch;
 	$output = '';
 	if ( get_option( 'use_smilies' ) && ! empty( $wp_smiliessearch ) ) {
+
+		//Convert null to empty string to prevent splitting of null variable
+		if(is_null($text)){ $text = ''; }
+		
 		// HTML loop taken from texturize function, could possible be consolidated.
 		$textarr = preg_split( '/(<.*>)/U', $text, -1, PREG_SPLIT_DELIM_CAPTURE ); // Capture the tags as well as in between.
 		$stop    = count( $textarr ); // Loop stuff.


### PR DESCRIPTION
changes convert_smilies function to be usable on PHP8.2 without deprecation by converting the $text variable when null, to an empty string.

this is meant as a workaround until PHP8.2 function syntax is fully implemented

Current error on PHP 8.2: 
PHP Deprecated:  preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated