### PR TITLE
walk_page_tree issue - cast array to object to fix

### DIFF
--- a/wp-includes/post-template.php
+++ b/wp-includes/post-template.php
@@ -1564,7 +1564,7 @@ function walk_page_tree( $pages, $depth, $current_page, $args ) {
 		}
 	}
 
-	return $walker->walk( $pages, $depth, $args, $current_page );
+	return $walker->walk( $pages, $depth, (object) $args, $current_page );
 }
 
 /**


### PR DESCRIPTION
( ! ) Warning: Attempt to read property "before" on array in C:\WinNMP\WWW\wordpress\wp-includes\class-walker-nav-menu.php on line 273

$walker->walk expects an object but
walk_page_tree passes an array.