### PR TITLE
Patch/60304 Improve performance of unpack PHP function

### DIFF
--- a/wp-includes/ID3/module.audio-video.quicktime.php
+++ b/wp-includes/ID3/module.audio-video.quicktime.php
@@ -1755,7 +1755,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 
 				case 'uuid': // user-defined atom often seen containing XML data, also used for potentially many other purposes, only a few specifically handled by getID3 (e.g. 360fly spatial data)
 					//Get the UUID ID in first 16 bytes
-					$uuid_bytes_read = unpack('H8time_low/H4time_mid/H4time_hi/H4clock_seq_hi/H12clock_seq_low', substr($atom_data, 0, 16));
+					$uuid_bytes_read = unpack('H8time_low/H4time_mid/H4time_hi/H4clock_seq_hi/H12clock_seq_low', $atom_data, 0);
 					$atom_structure['uuid_field_id'] = implode('-', $uuid_bytes_read);
 
 					switch ($atom_structure['uuid_field_id']) {   // http://fileformats.archiveteam.org/wiki/Boxes/atoms_format#UUID_boxes
@@ -1781,7 +1781,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 							$atom_structure['title'] = '360Fly Sensor Data';
 
 							//Get the UUID HEADER data
-							$uuid_bytes_read = unpack('vheader_size/vheader_version/vtimescale/vhardware_version/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/', substr($atom_data, 16, 32));
+							$uuid_bytes_read = unpack('vheader_size/vheader_version/vtimescale/vhardware_version/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/x/', $atom_data, 16);
 							$atom_structure['uuid_header'] = $uuid_bytes_read;
 
 							$start_byte = 48;
@@ -1905,7 +1905,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 						if ((strlen($atom_data) % $GPS_rowsize) == 0) {
 							$atom_structure['gps_toc'] = array();
 							foreach (str_split($atom_data, $GPS_rowsize) as $counter => $datapair) {
-								$atom_structure['gps_toc'][] = unpack('Noffset/Nsize', substr($atom_data, $counter * $GPS_rowsize, $GPS_rowsize));
+								$atom_structure['gps_toc'][] = unpack('Noffset/Nsize', $atom_data, $counter * $GPS_rowsize);
 							}
 
 							$atom_structure['gps_entries'] = array();

--- a/wp-includes/Requests/src/Requests.php
+++ b/wp-includes/Requests/src/Requests.php
@@ -1001,7 +1001,7 @@ class Requests {
 			$flg = ord(substr($gz_data, 3, 1));
 			if ($flg > 0) {
 				if ($flg & 4) {
-					list($xlen) = unpack('v', substr($gz_data, $i, 2));
+					list($xlen) = unpack('v', $gz_data, $i);
 					$i         += 2 + $xlen;
 				}
 
@@ -1058,7 +1058,7 @@ class Requests {
 			// Offset 28: 2 bytes, optional field length
 			// Offset 30: Filename field, followed by optional field, followed
 			// immediately by data
-			list(, $general_purpose_flag) = unpack('v', substr($gz_data, 6, 2));
+			list(, $general_purpose_flag) = unpack('v', $gz_data, 6);
 
 			// If the file has been compressed on the fly, 0x08 bit is set of
 			// the general purpose field. We can use this to differentiate
@@ -1072,7 +1072,7 @@ class Requests {
 
 			// Determine the first byte of data, based on the above ZIP header
 			// offsets:
-			$first_file_start = array_sum(unpack('v2', substr($gz_data, 26, 4)));
+			$first_file_start = array_sum(unpack('v2', $gz_data, 26));
 			$decompressed     = @gzinflate(substr($gz_data, 30 + $first_file_start));
 			if ($decompressed !== false) {
 				return $decompressed;

--- a/wp-includes/SimplePie/gzdecode.php
+++ b/wp-includes/SimplePie/gzdecode.php
@@ -250,7 +250,7 @@ class SimplePie_gzdecode
 				}
 
 				// Get the length of the extra field
-				$len = current(unpack('v', substr($this->compressed_data, $this->position, 2)));
+				$len = current(unpack('v', $this->compressed_data, $this->position));
 				$this->position += 2;
 
 				// Check the length of the string is still valid
@@ -315,7 +315,7 @@ class SimplePie_gzdecode
 				if ($this->compressed_size >= $this->min_compressed_size)
 				{
 					// Read the CRC
-					$crc = current(unpack('v', substr($this->compressed_data, $this->position, 2)));
+					$crc = current(unpack('v', $this->compressed_data, $this->position));
 
 					// Check the CRC matches
 					if ((crc32(substr($this->compressed_data, 0, $this->position)) & 0xFFFF) === $crc)
@@ -342,7 +342,7 @@ class SimplePie_gzdecode
 			$this->position = $this->compressed_size - 8;
 
 			// Check CRC of data
-			$crc = current(unpack('V', substr($this->compressed_data, $this->position, 4)));
+			$crc = current(unpack('V', $this->compressed_data, $this->position));
 			$this->position += 4;
 			/*if (extension_loaded('hash') && sprintf('%u', current(unpack('V', hash('crc32b', $this->data)))) !== sprintf('%u', $crc))
 			{
@@ -350,7 +350,7 @@ class SimplePie_gzdecode
 			}*/
 
 			// Check ISIZE of data
-			$isize = current(unpack('V', substr($this->compressed_data, $this->position, 4)));
+			$isize = current(unpack('V', $this->compressed_data, $this->position));
 			$this->position += 4;
 			if (sprintf('%u', strlen($this->data) & 0xFFFFFFFF) !== sprintf('%u', $isize))
 			{

--- a/wp-includes/class-wp-http-encoding.php
+++ b/wp-includes/class-wp-http-encoding.php
@@ -109,7 +109,7 @@ class WP_Http_Encoding {
 			$flg = ord( substr( $gz_data, 3, 1 ) );
 			if ( $flg > 0 ) {
 				if ( $flg & 4 ) {
-					list($xlen) = unpack( 'v', substr( $gz_data, $i, 2 ) );
+					list($xlen) = unpack( 'v', $gz_data, $i );
 					$i          = $i + 2 + $xlen;
 				}
 				if ( $flg & 8 ) {

--- a/wp-includes/media.php
+++ b/wp-includes/media.php
@@ -5587,14 +5587,14 @@ function wp_get_webp_info( $filename ) {
 	switch ( substr( $magic, 12, 4 ) ) {
 		// Lossy WebP.
 		case 'VP8 ':
-			$parts  = unpack( 'v2', substr( $magic, 26, 4 ) );
+			$parts  = unpack( 'v2', $magic, 26 );
 			$width  = (int) ( $parts[1] & 0x3FFF );
 			$height = (int) ( $parts[2] & 0x3FFF );
 			$type   = 'lossy';
 			break;
 		// Lossless WebP.
 		case 'VP8L':
-			$parts  = unpack( 'C4', substr( $magic, 21, 4 ) );
+			$parts  = unpack( 'C4', $magic, 21 );
 			$width  = (int) ( $parts[1] | ( ( $parts[2] & 0x3F ) << 8 ) ) + 1;
 			$height = (int) ( ( ( $parts[2] & 0xC0 ) >> 6 ) | ( $parts[3] << 2 ) | ( ( $parts[4] & 0x03 ) << 10 ) ) + 1;
 			$type   = 'lossless';


### PR DESCRIPTION
Speed up `unpack` performance by using offset argument instead of `substr` (available since PHP 7.1).

Trac ticket: https://core.trac.wordpress.org/ticket/60304