### PR TITLE
PHP Deprecate Error Fix Update shortcodes.php

### DIFF
--- a/wp-includes/shortcodes.php
+++ b/wp-includes/shortcodes.php
@@ -147,26 +147,26 @@ function shortcode_exists( $tag ) {
  * @return bool Whether the passed content contains the given shortcode.
  */
 function has_shortcode( $content, $tag ) {
-	if ( ! str_contains( $content, '[' ) ) {
-		return false;
-	}
+      if ( $content === null || ! str_contains( $content, '[' ) ) {
+          return false;
+      }
 
-	if ( shortcode_exists( $tag ) ) {
-		preg_match_all( '/' . get_shortcode_regex() . '/', $content, $matches, PREG_SET_ORDER );
-		if ( empty( $matches ) ) {
-			return false;
-		}
+      if ( shortcode_exists( $tag ) ) {
+          preg_match_all( '/' . get_shortcode_regex() . '/', $content, $matches, PREG_SET_ORDER );
+          if ( empty( $matches ) ) {
+              return false;
+          }
 
-		foreach ( $matches as $shortcode ) {
-			if ( $tag === $shortcode[2] ) {
-				return true;
-			} elseif ( ! empty( $shortcode[5] ) && has_shortcode( $shortcode[5], $tag ) ) {
-				return true;
-			}
-		}
-	}
-	return false;
-}
+          foreach ( $matches as $shortcode ) {
+              if ( $tag === $shortcode[2] ) {
+                  return true;
+              } elseif ( ! empty( $shortcode[5] ) && has_shortcode( $shortcode[5], $tag ) ) {
+                  return true;
+              }
+          }
+      }
+      return false;
+  }
 
 /**
  * Returns a list of registered shortcode names found in the given content.


### PR DESCRIPTION
[19-Feb-2024 03:49:42 UTC] PHP Deprecated:  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in /home/lucrecia/public_html/wp-includes/shortcodes.php on line 150