### PR TITLE
Add NGINX Unit detection and network info page

### DIFF
--- a/wp-admin/includes/network.php
+++ b/wp-admin/includes/network.php
@@ -424,7 +424,7 @@ function network_step1( $errors = false ) {
  * @param false|WP_Error $errors Optional. Error object. Default false.
  */
 function network_step2( $errors = false ) {
-	global $wpdb, $is_nginx;
+	global $wpdb, $is_nginx, $is_nginx_unit;
 
 	$hostname          = get_clean_basedomain();
 	$slashed_home      = trailingslashit( get_option( 'home' ) );
@@ -698,7 +698,17 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 		);
 		echo '</p></li>';
 
-	else : // End $is_nginx. Construct an .htaccess file instead:
+	elseif ( $is_nginx_unit ) : // End $is_nginx, check for NGINX Unit:
+
+		echo '<li><p>';
+		printf(
+			/* translators: %s: Documentation URL. */
+			__( 'It seems your network is running within Nginx UNIT. <a href="%s">Learn more about further configuration</a>.' ),
+			__( 'https://wordpress.org/documentation/article/nginx-unit/' )
+		);
+		echo '</p></li>';
+
+	else : // End $is_nginx_unit. Construct an .htaccess file instead:
 
 		$ms_files_rewriting = '';
 		if ( is_multisite() && get_site_option( 'ms_files_rewriting' ) ) {

--- a/wp-includes/vars.php
+++ b/wp-includes/vars.php
@@ -17,7 +17,7 @@
 
 global $pagenow,
 	$is_lynx, $is_gecko, $is_winIE, $is_macIE, $is_opera, $is_NS4, $is_safari, $is_chrome, $is_iphone, $is_IE, $is_edge,
-	$is_apache, $is_IIS, $is_iis7, $is_nginx, $is_caddy;
+	$is_apache, $is_IIS, $is_iis7, $is_nginx, $is_nginx_unit, $is_caddy;
 
 // On which page are we?
 if ( is_admin() ) {
@@ -125,6 +125,13 @@ $is_apache = ( str_contains( $_SERVER['SERVER_SOFTWARE'], 'Apache' ) || str_cont
  * @global bool $is_nginx
  */
 $is_nginx = ( str_contains( $_SERVER['SERVER_SOFTWARE'], 'nginx' ) );
+
+/**
+ * Whether the server software is NGINX Unit or something else
+ *
+ * @global bool $is_nginx
+ */
+$is_nginx_unit = ( str_contains( $_SERVER['SERVER_SOFTWARE'], 'Unit/' ) );
 
 /**
  * Whether the server software is Caddy or something else.


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/60582

* Adds a new global variable `is_nginx_unit`
* Makes use of it in the network setup screen to link to documentation relating to Unit