### PR TITLE
Font Library: `mb_strtolower()` throws fatal without the optional `mbstring` PHP extension installed.

### DIFF
--- a/wp-includes/fonts/class-wp-font-utils.php
+++ b/wp-includes/fonts/class-wp-font-utils.php
@@ -110,8 +110,11 @@ class WP_Font_Utils {
 			'unicodeRange' => 'U+0-10FFFF',
 		);
 		$settings = wp_parse_args( $settings, $defaults );
-
-		$font_family   = mb_strtolower( $settings['fontFamily'] );
+		if ( function_exists( 'mb_strtolower' ) ) {
+			$font_family   = mb_strtolower( $settings['fontFamily'] );
+		}else{
+			$font_family   = strtolower( $settings['fontFamily'] );
+		}	
 		$font_style    = strtolower( $settings['fontStyle'] );
 		$font_weight   = strtolower( $settings['fontWeight'] );
 		$font_stretch  = strtolower( $settings['fontStretch'] );


### PR DESCRIPTION

mbstring PHP package is optional, this should be wrapped by a function_exists() check and fall back to strtolower() if the function is not available.

https://core.trac.wordpress.org/ticket/60823