### PR TITLE
Update mce-view.js DOM text reinterpreted as HTML

### DIFF
--- a/wp-includes/js/mce-view.js
+++ b/wp-includes/js/mce-view.js
@@ -489,7 +489,7 @@
 					}
 
 					editor.undoManager.transact( function() {
-						node.innerHTML = '';
+						node.innerText = '';
 						node.appendChild( _.isString( content ) ? editor.dom.createFragment( content ) : content );
 						editor.dom.add( node, 'span', { 'class': 'wpview-end' } );
 					} );


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.