### PR TITLE
Bugfix: TypeError count(): Argument #1 ($value) must be of type Count…

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -3492,7 +3492,7 @@ function convert_smilies( $text ) {
 	if ( get_option( 'use_smilies' ) && ! empty( $wp_smiliessearch ) ) {
 		// HTML loop taken from texturize function, could possible be consolidated.
 		$textarr = preg_split( '/(<.*>)/U', $text, -1, PREG_SPLIT_DELIM_CAPTURE ); // Capture the tags as well as in between.
-		$stop    = count( $textarr ); // Loop stuff.
+		$stop = is_countable($textarr) ? count($textarr) : 0;
 
 		// Ignore processing of specific tags.
 		$tags_to_ignore       = 'code|pre|style|script|textarea';


### PR DESCRIPTION
The issue is happening in the convert_smilies function, located in the formatting.php file at line 3507. Specifically, the error occurs on the line where it tries to count the elements in the $textarr array.