### PR TITLE
fix(is_ssl): adds check for ssl when behind a proxy or load balancer

### DIFF
--- a/wp-includes/load.php
+++ b/wp-includes/load.php
@@ -1625,6 +1625,8 @@ function is_ssl() {
 		}
 	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' === (string) $_SERVER['SERVER_PORT'] ) ) {
 		return true;
+	} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && ('https' === strtolower( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) ) {
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
When hosting WordPress behind a reverse proxy or a load balancer and the site URL is configured to start with `https` (Admin -> Settings -> General -> WordPress Address & Site Address) , it isn't possible to login or view administration due to too many redirects. WordPress gets caught in a redirect loop and the browser shows an error page this effect.

This is caused by the request URI (`$_SERVER['REQUEST_URI']`) being re-written by the reverse proxy or load balancer so the checks in `wp-login.php` and `wp-admin/index.php` fail.

However, the convention in this configuration is to set additional HTTP headers which this PR adds a check for.

I've tested this on the latest [WordPress docker](https://hub.docker.com/_/wordpress) container behind an nginx reverse proxy.