### PR TITLE
Enhance `wp_hash` function to support custom hashing algorithms

### DIFF
--- a/wp-includes/pluggable.php
+++ b/wp-includes/pluggable.php
@@ -2553,12 +2553,19 @@ if ( ! function_exists( 'wp_hash' ) ) :
 	 *
 	 * @param string $data   Plain text to hash.
 	 * @param string $scheme Authentication scheme (auth, secure_auth, logged_in, nonce).
+	 * @param string $algo   Hashing algorithm to use (default: md5).
 	 * @return string Hash of $data.
 	 */
-	function wp_hash( $data, $scheme = 'auth' ) {
+	function wp_hash( $data, $scheme = 'auth', $algo = 'md5' ) {
 		$salt = wp_salt( $scheme );
 
-		return hash_hmac( 'md5', $data, $salt );
+		// Ensure the algorithm is supported by the hash_hmac function.
+		if ( ! in_array( $algo, hash_hmac_algos(), true ) ) {
+			// Fall back to 'md5' if the provided algorithm is not supported.
+			$algo = 'md5';
+		}
+
+		return hash_hmac( $algo, $data, $salt );
 	}
 endif;
 


### PR DESCRIPTION
### Summary
This PR updates the `wp_hash` function to allow users to specify a custom hashing algorithm, enhancing the security and flexibility of the function. Previously, the function hardcoded the `md5` algorithm, which is vulnerable to collision attacks.

### Changes:
- Added a new parameter `$algo` to the `wp_hash` function, allowing users to specify the hashing algorithm. The default remains `md5` for backward compatibility.
- Implemented a check using `hash_hmac_algos()` to ensure the provided algorithm is supported. If not, the function will fall back to `md5`.

### Benefits:
- Users can now choose more secure hashing algorithms like `sha256`.
- Improved security by allowing the use of modern, collision-resistant hashing algorithms.

### Backward Compatibility:
- The function retains `md5` as the default algorithm, ensuring backward compatibility with existing code.

### Testing:
- Tested with various algorithms (`md5`, `sha256`, `sha512`) to confirm correct functionality.
- Validated fallback to `md5` when an unsupported algorithm is provided.
