### PR TITLE
Suggestion: Disable PHPCS for the l10n.php translation files

### DIFF
--- a/wp-includes/l10n/class-wp-translation-file-php.php
+++ b/wp-includes/l10n/class-wp-translation-file-php.php
@@ -47,7 +47,7 @@ class WP_Translation_File_PHP extends WP_Translation_File {
 	public function export(): string {
 		$data = array_merge( $this->headers, array( 'messages' => $this->entries ) );
 
-		return '<?php' . PHP_EOL . 'return ' . $this->var_export( $data ) . ';' . PHP_EOL;
+		return '<?php // phpcs:disable' . PHP_EOL . 'return ' . $this->var_export( $data ) . ';' . PHP_EOL;
 	}
 
 	/**


### PR DESCRIPTION
Disable PHPCS for l10n.php translation files. 

I know not everyone applies WP Coding Standards (though everyone should), but for those who do, the generated l10n file is anything but WPCS compliant, so we disable PHPCS :)