### PR TITLE
Add ability to developers to add their own plugin statuses via a filt…

### DIFF
--- a/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/wp-admin/includes/class-wp-plugins-list-table.php
@@ -47,7 +47,14 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		);
 
 		$allowed_statuses = array( 'active', 'inactive', 'recently_activated', 'upgrade', 'mustuse', 'dropins', 'search', 'paused', 'auto-update-enabled', 'auto-update-disabled' );
-
+		
+		/**
+		 * Filters the plugin allowed statuses.
+		 *
+		 * @param array $allowed_statuses The array of plugin allowed statuses.
+		 */
+		$allowed_statuses = apply_filters('plugin_allowed_statuses', $allowed_statuses);
+		
 		$status = 'all';
 		if ( isset( $_REQUEST['plugin_status'] ) && in_array( $_REQUEST['plugin_status'], $allowed_statuses, true ) ) {
 			$status = $_REQUEST['plugin_status'];


### PR DESCRIPTION
For example, my case was to add plugin status fav_plugins, and I have write this work around to init the plugin_status:

```
// Workaround
add_filter('plugins_auto_update_enabled', function($enabled){
	if( !is_admin() ) return $enabled;

	global $pagenow;
	if( $pagenow != 'plugins.php' ) return $enabled;

	$plugin_status = $_GET['plugin_status'] ?? '';
	if( $plugin_status != 'fav_plugins' ) return $enabled;

	$GLOBALS['status'] = 'fav_plugins';

	return $enabled;
});
```