### PR TITLE
Fix registration bypass

### DIFF
--- a/wp-login.php
+++ b/wp-login.php
@@ -13,7 +13,7 @@ require __DIR__ . '/wp-load.php';
 
 // 🔴 Security Fix: Prevent user registration if "Anyone can register" is disabled
 if (isset($_GET['action']) && $_GET['action'] === 'register' && !get_option('users_can_register')) {
-    wp_die('Inscription désactivée.', 'Erreur', array('response' => 403));
+    wp_die('Registration disabled.', 'Erreur', array('response' => 403));
 }
 
 // Redirect to HTTPS login if forced to use SSL.

--- a/wp-login.php
+++ b/wp-login.php
@@ -11,6 +11,11 @@
 /** Make sure that the WordPress bootstrap has run before continuing. */
 require __DIR__ . '/wp-load.php';
 
+// 🔴 Security Fix: Prevent user registration if "Anyone can register" is disabled
+if (isset($_GET['action']) && $_GET['action'] === 'register' && !get_option('users_can_register')) {
+    wp_die('Inscription désactivée.', 'Erreur', array('response' => 403));
+}
+
 // Redirect to HTTPS login if forced to use SSL.
 if ( force_ssl_admin() && ! is_ssl() ) {
 	if ( str_starts_with( $_SERVER['REQUEST_URI'], 'http' ) ) {


### PR DESCRIPTION
<h2>Fix: Prevent registration bypass when user registration is disabled</h2>

<h3>Problem Description:</h3>
<p>
After extensive testing, I discovered a potential vulnerability in the default WordPress registration form. This issue occurs even when user registration is disabled (<code>users_can_register</code> set to <code>0</code>). It allows spammers to bypass the restriction and create accounts, resulting in spam registrations and automated email notifications.
</p>

<h3>Steps to Reproduce:</h3>
<ol>
    <li><strong>Send a POST request</strong> to <code>/wp-login.php?action=register</code>.</li>
    <li><strong>Headers:</strong></li>
    <ul>
        <li>Content-Type: <code>application/x-www-form-urlencoded</code></li>
    </ul>
    <li><strong>Body</strong> (as <code>x-www-form-urlencoded</code>):</li>
    <pre>
user_login=testuser
user_email=testuser@example.com
user_pass=TestPassword123
wp-submit=Register
redirect_to=
    </pre>
    <li><strong>Response:</strong></li>
    <p>If the same request is repeated, an error is displayed indicating that the username and email are already in use.</p>
    <li><strong>Redirect Behavior:</strong></li>
    <p>The bypass works only when redirect following is disabled.</p>
</ol>

<h3>Root Cause:</h3>
<p>
The <code>wp-login.php</code> file does not validate whether the <code>users_can_register</code> option is disabled when processing registration requests.
</p>

<h3>Solution:</h3>
<p>
This pull request introduces a check to block access to the registration process if the <code>users_can_register</code> option is set to <code>0</code>. This ensures that no new accounts can be created through this endpoint unless registration is explicitly enabled.
</p>
