### PR TITLE
Fixed: Undefined array key in /wp-includes/formatting.php at php8.4

### DIFF
--- a/wp-includes/formatting.php
+++ b/wp-includes/formatting.php
@@ -3451,7 +3451,7 @@ function translate_smiley( $matches ) {
 	}
 
 	$smiley = trim( reset( $matches ) );
-	$img    = $wpsmiliestrans[ $smiley ];
+	$img    = isset($wpsmiliestrans[ $smiley ]) ? $wpsmiliestrans[ $smiley ] : '';
 
 	$matches    = array();
 	$ext        = preg_match( '/\.([^.]+)$/', $img, $matches ) ? strtolower( $matches[1] ) : false;


### PR DESCRIPTION
Fixed: Undefined array key in /wp-includes/formatting.php