### PR TITLE
Add dynamic metadata filters similar to options

### DIFF
--- a/wp-includes/meta.php
+++ b/wp-includes/meta.php
@@ -600,12 +600,47 @@ function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $
  */
 function get_metadata( $meta_type, $object_id, $meta_key = '', $single = false ) {
 	$value = get_metadata_raw( $meta_type, $object_id, $meta_key, $single );
+
 	if ( ! is_null( $value ) ) {
+		/**
+		 * Filters the value of metadata after it is retrieved.
+		 *
+		 * The dynamic portion of the hook name, `$meta_type`, refers to the meta
+		 * object type (post, comment, term, user, etc).
+		 *
+		 * The dynamic portion of the hook name, `$meta_key`, refers to the specific
+		 * meta key (when provided).
+		 *
+		 * Examples:
+		 *  - post_metadata
+		 *  - user_metadata
+		 *  - user_metadata_nickname
+		 *
+		 * @param mixed  $value     The metadata value.
+		 * @param int    $object_id Object ID.
+		 * @param string $meta_key  Metadata key.
+		 * @param bool   $single    Whether only the first value should be returned.
+		 */
+		$value = apply_filters( "{$meta_type}_metadata", $value, $object_id, $meta_key, $single );
+
+		if ( $meta_key ) {
+			$value = apply_filters( "{$meta_type}_metadata_{$meta_key}", $value, $object_id, $single );
+		}
+
 		return $value;
 	}
 
-	return get_metadata_default( $meta_type, $object_id, $meta_key, $single );
+	$default = get_metadata_default( $meta_type, $object_id, $meta_key, $single );
+
+	$default = apply_filters( "{$meta_type}_metadata", $default, $object_id, $meta_key, $single );
+
+	if ( $meta_key ) {
+		$default = apply_filters( "{$meta_type}_metadata_{$meta_key}", $default, $object_id, $single );
+	}
+
+	return $default;
 }
+
 
 /**
  * Retrieves raw metadata value for the specified object.


### PR DESCRIPTION
## Change

Extended the get_metadata() function to apply two levels of filters after retrieving metadata:

{$meta_type}_metadata → runs for all meta keys of a given object type (e.g. user_metadata).

{$meta_type}_metadata_{$meta_key} → runs for a specific meta key (e.g. user_metadata_nickname).

## Why

Aligns metadata handling with how get_option() works, which has both a general filter (option_{$option}) and the ability to target specific values.

Provides developers more granular control:

Use the general filter to adjust all metadata of a type.

Use the meta-key-specific filter to target one field only.

## Example usage
```php 
// Affect all user metadata
add_filter( 'user_metadata', function( $value, $user_id, $meta_key, $single ) {
    return $value === '' ? 'N/A' : $value;
}, 10, 4 );

// Affect only the nickname field
add_filter( 'user_metadata_nickname', function( $value, $user_id, $single ) {
    return 'SuperHero';
}, 10, 3 );

```